### PR TITLE
Update traefik example

### DIFF
--- a/examples/google-cloud/rollout.yml
+++ b/examples/google-cloud/rollout.yml
@@ -4,7 +4,6 @@ metadata:
   name: rollouts-demo
   namespace: default
 spec:
-  revisionHistoryLimit: 1
   replicas: 10
   strategy:
     canary:

--- a/examples/traefik/README.md
+++ b/examples/traefik/README.md
@@ -63,7 +63,6 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: traefik-controller-role
   namespace: aws-local-runtime
 rules:
@@ -203,8 +202,21 @@ spec:
   selector:
     app: rollouts-demo
 ```
+## Step 6 - Grant argo-rollouts permissions to view and modify Gateway HTTPRoute resources
 
-## Step 6 - Create argo-rollouts resources
+The argo-rollouts service account needs the ability to be able to view and mofiy HTTPRoutes as well as its existing permissions. Edit the `argo-rollouts` cluster role to add the following permissions:
+
+```yaml
+rules:
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - '*'
+```
+
+## Step 7 - Create argo-rollouts resources
 
 We can finally create the definition of the application.
 
@@ -223,6 +235,7 @@ spec:
         plugins:
           argoproj-labs/gatewayAPI:
             httpRoute: argo-rollouts-http-route # our created httproute
+            namespace: default # namespace where this rollout resides.
       steps:
         - setWeight: 30
         - pause: {}
@@ -256,7 +269,7 @@ spec:
 
 Apply all the yaml files to your cluster
 
-## Step 7 - Test the canary
+## Step 8 - Test the canary
 
 Perform a deployment like any other Rollout and the Gateway plugin will split the traffic to your canary by instructing Traefik proxy via the Gateway API
 

--- a/examples/traefik/cluster-role.yml
+++ b/examples/traefik/cluster-role.yml
@@ -1,9 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: traefik-controller-role
-  namespace: aws-local-runtime
 rules:
   - apiGroups:
       - "*"

--- a/examples/traefik/httproute.yml
+++ b/examples/traefik/httproute.yml
@@ -5,6 +5,7 @@ metadata:
 spec:
   parentRefs:
     - name: argo-rollouts-gateway
+      namespace: default
   rules:
     - backendRefs:
         - name: argo-rollouts-stable-service

--- a/examples/traefik/rollout.yml
+++ b/examples/traefik/rollout.yml
@@ -12,6 +12,7 @@ spec:
         plugins:
           argoproj-labs/gatewayAPI:
             httpRoute: argo-rollouts-http-route # our created httproute
+            namespace: default # namespace where this rollout resides
       steps:
         - setWeight: 30
         - pause: {}


### PR DESCRIPTION
Update traefik example as it was missing a `namespace` setting in the rollout plugin spec. Additionally, add missing RBAC configuration and remove some erroneous creationTimestamp fields.

- Remove duplicate revisionHistoryLimit in google cloud rollout