### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ data:
 
 Deploy this file with `kubectl` or Argo CD or any other deployment method you use for your cluster.
 
+Restart the Argo Rollouts pod for the plug-in to take effect.
+```shell
+kubectl rollout restart deployment -n argo-rollouts argo-rollouts
+```
+
 For more details see the [Plugin documentation](https://argoproj.github.io/argo-rollouts/features/traffic-management/plugins/) at Argo Rollouts.
 
 ## Feedback needed


### PR DESCRIPTION
I spent hours trying to configure Google Cloud Traffic Management based on an example. There was no mention of the necessity to restart the Argo Rollouts pod (controller).