### PR TITLE
feat: return update errors

### DIFF
--- a/pkg/plugin/httproute.go
+++ b/pkg/plugin/httproute.go
@@ -52,8 +52,6 @@ func (r *RpcPlugin) setHTTPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight 
 		r.UpdatedHTTPRouteMock = updatedHTTPRoute
 	}
 	if err != nil {
-		msg := fmt.Sprintf(GatewayAPIUpdateError, httpRoute.GetName(), err)
-		r.LogCtx.Error(msg)
 		return pluginTypes.RpcError{
 			ErrorString: err.Error(),
 		}

--- a/pkg/plugin/httproute.go
+++ b/pkg/plugin/httproute.go
@@ -54,6 +54,9 @@ func (r *RpcPlugin) setHTTPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight 
 	if err != nil {
 		msg := fmt.Sprintf(GatewayAPIUpdateError, httpRoute.GetName(), err)
 		r.LogCtx.Error(msg)
+		return pluginTypes.RpcError{
+			ErrorString: err.Error(),
+		}
 	}
 	return pluginTypes.RpcError{}
 }

--- a/pkg/plugin/tcproute.go
+++ b/pkg/plugin/tcproute.go
@@ -48,6 +48,9 @@ func (r *RpcPlugin) setTCPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight i
 	if err != nil {
 		msg := fmt.Sprintf(GatewayAPIUpdateError, tcpRoute.GetName(), err)
 		r.LogCtx.Error(msg)
+		return pluginTypes.RpcError{
+			ErrorString: err.Error(),
+		}
 	}
 	return pluginTypes.RpcError{}
 }

--- a/pkg/plugin/tcproute.go
+++ b/pkg/plugin/tcproute.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	pluginTypes "github.com/argoproj/argo-rollouts/utils/plugin/types"
@@ -46,8 +45,6 @@ func (r *RpcPlugin) setTCPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight i
 		r.UpdatedTCPRouteMock = updatedTCPRoute
 	}
 	if err != nil {
-		msg := fmt.Sprintf(GatewayAPIUpdateError, tcpRoute.GetName(), err)
-		r.LogCtx.Error(msg)
 		return pluginTypes.RpcError{
 			ErrorString: err.Error(),
 		}


### PR DESCRIPTION
Sometimes the plugin prints the following error during an update. It might be better to return the error so it could be retried, or use patch instead of update.

```
2024-04-26T09:51:14.001Z [DEBUG] plugin.gatewayAPI: time="2024-04-26T09:51:14Z" level=error msg="error updating Gateway API \"app-widgets\": Operation cannot be fulfilled on httproutes.gateway.networking.k8s.io \"app-widgets\": the object has been modified; please apply your changes to the latest version and try again" plugin=trafficrouter
```