### PR TITLE
feat: configurable HTTP route version

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/internal/utils"
 	"github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/pkg/plugin"
 
@@ -19,12 +21,16 @@ var handshakeConfig = goPlugin.HandshakeConfig{
 	MagicCookieValue: "trafficrouter",
 }
 
+var httpRouteAPIVersion = flag.String("http-route-api-version", "v1", "HTTPRoute version")
+
 func main() {
+	flag.Parse()
 	logCtx := log.WithFields(log.Fields{"plugin": "trafficrouter"})
 	utils.SetLogLevel("debug")
 	log.SetFormatter(utils.CreateFormatter("text"))
 	rpcPluginImp := &plugin.RpcPlugin{
-		LogCtx: logCtx,
+		LogCtx:              logCtx,
+		HTTPRouteAPIVersion: *httpRouteAPIVersion,
 	}
 	//  pluginMap is the map of plugins we can dispense.
 	var pluginMap = map[string]goPlugin.Plugin{

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -24,6 +24,7 @@ type RpcPlugin struct {
 	UpdatedTCPRouteMock  *v1alpha2.TCPRoute
 	HTTPRouteClient      gatewayApiClientv1.HTTPRouteInterface
 	TCPRouteClient       gatewayApiClientv1alpha2.TCPRouteInterface
+	HTTPRouteAPIVersion  string
 }
 
 type GatewayAPITrafficRouting struct {


### PR DESCRIPTION
Some Gateway API implementations do not support Gateway API v1 yet. (e.g. GKE) I added a new flag `http-route-api-version` for users to configure HTTP route version during plugin initialization. This feature requires https://github.com/argoproj/argo-rollouts/pull/2992 which is introduced in Argo Rollouts v1.7.0-rc1.

```yaml
trafficRouterPlugins:
  name: argoproj-labs/gatewayAPI
  location: https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.2.0/gateway-api-plugin-linux-amd64
  args:
    - "--http-route-api-version"
    - v1beta1
```