### PR TITLE
Updated the gateway-controller-role ClusterRole permissions

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -89,11 +89,13 @@ metadata:
   namespace: argo-rollouts
 rules:
   - apiGroups:
-      - "*"
+      - gateway.networking.k8s.io
     resources:
-      - "*"
+      - httproutes
     verbs:
-      - "*"
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This PR is to update the gateway-controller-role ClusterRole permissions as reported in https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/issues/68