### PR TITLE
docs: Update Documentation for Gateway API Plugin Versioning

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,7 +58,7 @@ kubectl rollout restart deployment -n argo-rollouts argo-rollouts
 Then check the controller logs. You should see a line for loading the plugin:
 
 ```
-time="XXX" level=info msg="Downloading plugin argoproj-labs/gatewayAPI from: https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.2.0/gateway-api-plugin-linux-amd64"
+time="XXX" level=info msg="Downloading plugin argoproj-labs/gatewayAPI from: https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.4.0/gatewayapi-plugin-linux-amd64"
 time="YYY" level=info msg="Download complete, it took 7.792426599s" 
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,7 +24,7 @@ metadata:
 data:
   trafficRouterPlugins: |-
     - name: "argoproj-labs/gatewayAPI"
-      location: "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/<version>/gateway-api-plugin-<arch>"
+      location: "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/<version>/gatewayapi-plugin-<arch>"
 ```
 
 You can find the available versions and architectures at the [Releases page](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases).
@@ -40,7 +40,7 @@ metadata:
 data:
   trafficRouterPlugins: |-
     - name: "argoproj-labs/gatewayAPI"
-      location: "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.2.0/gateway-api-plugin-linux-amd64"
+      location: "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.4.0/gatewayapi-plugin-linux-amd64"
 ```
 
 Deploy this file with `kubectl apply -f gateway-plugin.yml -n argo-rollouts`. You can also use [Argo CD](https://argoproj.github.io/cd/) or any other Kubernetes deployment method that you prefer.


### PR DESCRIPTION
In the description box, you can provide more detailed information about your changes. Here's an example:

This pull request addresses an issue in the documentation for the Gateway API plugin. The following changes were made:

Updated the plugin's name reference from gateway-api to gatewayapi to align with version 4.0 updates.
Added a note to warn users about the removal of the hyphen (-) in the plugin name when updating the version.
Fixed outdated references on line 27.
These updates ensure that users have accurate and clear instructions for installing and using the Gateway API plugin. Let me know if there are further adjustments needed!