### PR TITLE
tests: increase e2e timout to account for flaky tests in GitHub actions

### DIFF
--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -44,8 +44,8 @@ const (
 
 const (
 	SHORT_PERIOD  = time.Second
-	MEDIUM_PERIOD = 5 * time.Second
-	LONG_PERIOD   = 10 * time.Second
+	MEDIUM_PERIOD = 30 * time.Second
+	LONG_PERIOD   = 60 * time.Second
 )
 
 var (


### PR DESCRIPTION
Several times some e2e tests fail without any code changes. I increased the timeouts for the different periods where we wait for a K8s resource to be updated or inserted.