### PR TITLE
Add experiment support for Gateway API traffic router

### DIFF
--- a/examples/google-cloud-experiment/Readme.md
+++ b/examples/google-cloud-experiment/Readme.md
@@ -1,0 +1,92 @@
+# Argo Rollouts Gateway API Experiment Support
+
+This feature adds support for conducting experiments with Argo Rollouts using the Kubernetes Gateway API. Experiments allow you to test multiple versions of your application simultaneously with precise control over traffic distribution.
+
+## Overview
+
+When using the Gateway API traffic router with Argo Rollouts, you can now define experiments that:
+
+- Automatically adjust traffic weights in HTTPRoutes for the additional services created for experiment variants
+- Clean up experiment services when experiments complete
+
+## How It Works
+
+The plugin automatically:
+
+1. Detects when an experiment is active in a rollout
+2. Adjusts the stable service weight to accommodate experiment traffic
+3. Adds experiment services to the HTTPRoute with appropriate weights
+4. Removes experiment services when the experiment completes
+
+## Example Usage
+
+The included example demonstrates a rollout with an experiment step that tests:
+- A baseline variant based on the stable version (10% traffic)
+- A canary variant based on the new version (10% traffic)
+
+During the experiment:
+- The stable service receives 80% of traffic (reduced from 100%)
+- The canary service continues to receive 0% traffic
+- The experiment variants receive their specified weights ( 10% , 10%)
+
+After the experiment completes, traffic distribution returns to normal with stable receiving 100% until the next step begins.
+
+### Sample Manifest
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: demo-app
+  namespace: demo
+spec:
+  strategy:
+    canary:
+      canaryService: demo-app-canary
+      stableService: demo-app-stable
+      trafficRouting:
+        plugins:
+          argoproj-labs/gatewayAPI:
+            httpRoute: demo-app-route
+            namespace: demo
+      steps:
+      - experiment:
+          duration: 5m
+          templates:
+          - name: experiment-baseline
+            specRef: stable
+            service:
+              name: demo-app-exp-baseline
+            weight: 10
+          - name: experiment-canary
+            specRef: canary
+            service:
+              name: demo-app-exp-canary
+            weight: 10
+      # Remaining steps...
+```
+
+## Implementation Details
+
+The experiment handler:
+
+1. Identifies the matching rule in the HTTPRoute for the rollout
+2. Checks if an experiment is active by examining `rollout.Status.Canary.CurrentExperiment`
+3. For active experiments:
+   - Sets the stable service weight to 80%
+   - Adds experiment services from `rollout.Status.Canary.Weights.Additional`
+4. For inactive experiments:
+   - Removes any experiment services from the HTTPRoute
+   - Resets the stable service weight to 100%
+
+## Requirements
+
+- Kubernetes cluster with Gateway API CRDs installed
+- Argo Rollouts v1.5.0 or newer
+- Simple HTTP Gateway (TLS configuration optional)
+
+## See Also
+
+- [Argo Rollouts Documentation](https://argoproj.github.io/argo-rollouts/)
+- [Gateway API Documentation](https://gateway-api.sigs.k8s.io/)
+- [Experiment Documentation](https://argoproj.github.io/argo-rollouts/features/experiment/)

--- a/examples/google-cloud-experiment/gateway.yaml
+++ b/examples/google-cloud-experiment/gateway.yaml
@@ -1,0 +1,14 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: app-gateway
+  namespace: demo
+spec:
+  gatewayClassName: gke-l7-rilb
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: All

--- a/examples/google-cloud-experiment/httproute.yaml
+++ b/examples/google-cloud-experiment/httproute.yaml
@@ -1,0 +1,24 @@
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: demo-app-route
+  namespace: demo
+  labels:
+    managed-by: external-dns
+spec:
+  parentRefs:
+  - kind: Gateway
+    name: app-gateway
+    namespace: demo
+  hostnames:
+  - "demo.example.com"
+  rules:
+  - backendRefs:
+    - name: demo-app-stable
+      namespace: demo
+      port: 80
+      weight: 100
+    - name: demo-app-canary
+      namespace: demo
+      port: 80
+      weight: 0

--- a/examples/google-cloud-experiment/rollout.yaml
+++ b/examples/google-cloud-experiment/rollout.yaml
@@ -1,0 +1,63 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: demo-app
+  namespace: demo
+spec:
+  replicas: 3
+  strategy:
+    canary:
+      canaryService: demo-app-canary
+      stableService: demo-app-stable
+      trafficRouting:
+        plugins:
+          argoproj-labs/gatewayAPI:
+            httpRoute: demo-app-route
+            namespace: demo
+      steps:
+      - experiment:
+          duration: 5m
+          templates:
+          - name: experiment-baseline
+            specRef: stable
+            service:
+              name: demo-app-exp-baseline
+            weight: 10
+            metadata:
+              labels:
+                app: demo-app
+          - name: experiment-canary
+            specRef: canary
+            service:
+              name: demo-app-exp-canary
+            weight: 15
+            metadata:
+              labels:
+                app: demo-app
+      - pause: {} # Empty pause means indefinite - will require manual promotion     
+      - setWeight: 30
+      - pause: { duration: 5m }
+      - setWeight: 60
+      - pause: { duration: 5m }
+      - setWeight: 100
+      - pause: { duration: 5m }
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: demo-app
+  template:
+    metadata:
+      labels:
+        app: demo-app
+    spec:
+      containers:
+      - name: demo-app
+        image: argoproj/rollouts-demo:blue # change to green for next version
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        resources:
+          requests:
+            memory: 64Mi
+            cpu: 10m

--- a/examples/google-cloud-experiment/service.yaml
+++ b/examples/google-cloud-experiment/service.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-app-canary
+  namespace: demo
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: demo-app
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-app-stable
+  namespace: demo
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: demo-app

--- a/pkg/plugin/experiment.go
+++ b/pkg/plugin/experiment.go
@@ -1,0 +1,139 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayApiClientset "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+)
+
+func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gatewayClient *gatewayApiClientset.Clientset, logger *logrus.Entry, rollout *v1alpha1.Rollout, httpRoute *gatewayv1.HTTPRoute) error {
+	ruleIdx := -1
+	stableService := rollout.Spec.Strategy.Canary.StableService
+	canaryService := rollout.Spec.Strategy.Canary.CanaryService
+
+	for i, rule := range httpRoute.Spec.Rules {
+		if ruleIdx != -1 {
+			break
+		}
+		for _, backendRef := range rule.BackendRefs {
+			if string(backendRef.Name) == stableService || string(backendRef.Name) == canaryService {
+				ruleIdx = i
+				break
+			}
+		}
+	}
+
+	if ruleIdx == -1 {
+		return fmt.Errorf("no matching rule found for rollout %s", rollout.Name)
+	}
+
+	isExperimentActive := rollout.Spec.Strategy.Canary != nil && rollout.Status.Canary.CurrentExperiment != ""
+
+	hasExperimentServices := false
+	for _, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
+		serviceName := string(backendRef.Name)
+		if serviceName != stableService && serviceName != canaryService {
+			hasExperimentServices = true
+			break
+		}
+	}
+
+	if isExperimentActive {
+		logger.Info(fmt.Sprintf("Found active experiment %s", rollout.Status.Canary.CurrentExperiment))
+
+		if len(rollout.Status.Canary.Weights.Additional) == 0 {
+			logger.Info("No experiment services found in rollout status, skipping experiment service addition")
+			return nil
+		}
+
+		stableWeight := int32(45)
+		for i, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
+			if string(backendRef.Name) == stableService {
+				httpRoute.Spec.Rules[ruleIdx].BackendRefs[i].Weight = &stableWeight
+				break
+			}
+		}
+
+		for _, additionalDestination := range rollout.Status.Canary.Weights.Additional {
+			serviceName := additionalDestination.ServiceName
+			weight := additionalDestination.Weight
+
+			exists := false
+			for _, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
+				if string(backendRef.Name) == serviceName {
+					exists = true
+					break
+				}
+			}
+
+			if !exists {
+				logger.Info(fmt.Sprintf("Adding experiment service to HTTPRoute: %s with weight %d", serviceName, weight))
+
+				service, err := clientset.CoreV1().Services(rollout.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
+				if err != nil {
+					logger.Warn(fmt.Sprintf("Failed to get service %s: %v", serviceName, err))
+					continue
+				}
+
+				port := gatewayv1.PortNumber(8080)
+				portName := "http"
+				for _, servicePort := range service.Spec.Ports {
+					if servicePort.Name == portName {
+						port = gatewayv1.PortNumber(servicePort.Port)
+						break
+					}
+				}
+
+				if len(service.Spec.Ports) > 0 && port == 8080 {
+					port = gatewayv1.PortNumber(service.Spec.Ports[0].Port)
+				}
+
+				namespace := gatewayv1.Namespace(rollout.Namespace)
+				httpRoute.Spec.Rules[ruleIdx].BackendRefs = append(httpRoute.Spec.Rules[ruleIdx].BackendRefs, gatewayv1.HTTPBackendRef{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name:      gatewayv1.ObjectName(serviceName),
+							Namespace: &namespace,
+							Port:      &port,
+						},
+						Weight: &weight,
+					},
+				})
+			}
+		}
+		return nil
+	}
+
+	if !isExperimentActive && hasExperimentServices {
+		logger.Info("Experiment is no longer active, removing experiment services from HTTPRoute")
+
+		stableWeight := int32(100)
+		filteredBackendRefs := []gatewayv1.HTTPBackendRef{}
+
+		for _, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
+			serviceName := string(backendRef.Name)
+
+			if serviceName == stableService {
+				backendRef.Weight = &stableWeight
+				filteredBackendRefs = append(filteredBackendRefs, backendRef)
+			} else if serviceName == canaryService {
+				zeroWeight := int32(0)
+				backendRef.Weight = &zeroWeight
+				filteredBackendRefs = append(filteredBackendRefs, backendRef)
+			} else {
+				logger.Info(fmt.Sprintf("Removing experiment service from HTTPRoute: %s", serviceName))
+			}
+		}
+
+		httpRoute.Spec.Rules[ruleIdx].BackendRefs = filteredBackendRefs
+		logger.Info("Experiment services removed from HTTPRoute")
+	}
+
+	return nil
+}

--- a/pkg/plugin/experiment_test.go
+++ b/pkg/plugin/experiment_test.go
@@ -1,0 +1,204 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestHandleExperiment_ExperimentStatusChecking(t *testing.T) {
+	stableService := "stable-svc"
+	canaryService := "canary-svc"
+
+	rollout := &v1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rollout-test",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.RolloutSpec{
+			Strategy: v1alpha1.RolloutStrategy{
+				Canary: &v1alpha1.CanaryStrategy{
+					StableService: stableService,
+					CanaryService: canaryService,
+				},
+			},
+		},
+		Status: v1alpha1.RolloutStatus{
+			Canary: v1alpha1.CanaryStatus{
+				CurrentExperiment: "active-experiment",
+			},
+		},
+	}
+
+	stableWeight := int32(100)
+	canaryWeight := int32(0)
+	httpRoute := &gatewayv1.HTTPRoute{
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName(stableService),
+								},
+								Weight: &stableWeight,
+							},
+						},
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName(canaryService),
+								},
+								Weight: &canaryWeight,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	isExperimentActive := rollout.Spec.Strategy.Canary != nil && rollout.Status.Canary.CurrentExperiment != ""
+	assert.True(t, isExperimentActive, "Experiment should be detected as active")
+
+	hasExperimentServices := false
+	ruleIdx := 0
+	for _, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
+		serviceName := string(backendRef.Name)
+		if serviceName != stableService && serviceName != canaryService {
+			hasExperimentServices = true
+			break
+		}
+	}
+	assert.False(t, hasExperimentServices, "HTTPRoute should not have experiment services initially")
+
+	stableWeight = int32(45)
+	for i, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
+		if string(backendRef.Name) == stableService {
+			httpRoute.Spec.Rules[ruleIdx].BackendRefs[i].Weight = &stableWeight
+			break
+		}
+	}
+	assert.Equal(t, int32(45), *httpRoute.Spec.Rules[0].BackendRefs[0].Weight, "Should be able to modify the stable weight")
+}
+
+func TestHandleExperiment_RemoveExperimentServices(t *testing.T) {
+	stableService := "stable-svc"
+	canaryService := "canary-svc"
+	experimentSvc := "exp-svc"
+
+	rollout := &v1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rollout-test",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.RolloutSpec{
+			Strategy: v1alpha1.RolloutStrategy{
+				Canary: &v1alpha1.CanaryStrategy{
+					StableService: stableService,
+					CanaryService: canaryService,
+				},
+			},
+		},
+		Status: v1alpha1.RolloutStatus{
+			Canary: v1alpha1.CanaryStatus{
+				CurrentExperiment: "",
+			},
+		},
+	}
+
+	stableWeight := int32(45)
+	canaryWeight := int32(0)
+	experimentWeight := int32(15)
+	port := gatewayv1.PortNumber(8080)
+	namespace := gatewayv1.Namespace("default")
+
+	httpRoute := &gatewayv1.HTTPRoute{
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName(stableService),
+									Port: &port,
+								},
+								Weight: &stableWeight,
+							},
+						},
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName(canaryService),
+									Port: &port,
+								},
+								Weight: &canaryWeight,
+							},
+						},
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name:      gatewayv1.ObjectName(experimentSvc),
+									Namespace: &namespace,
+									Port:      &port,
+								},
+								Weight: &experimentWeight,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	isExperimentActive := rollout.Spec.Strategy.Canary != nil && rollout.Status.Canary.CurrentExperiment != ""
+	assert.False(t, isExperimentActive, "Experiment should be detected as inactive")
+
+	hasExperimentServices := false
+	ruleIdx := 0
+	for _, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
+		serviceName := string(backendRef.Name)
+		if serviceName != stableService && serviceName != canaryService {
+			hasExperimentServices = true
+			break
+		}
+	}
+	assert.True(t, hasExperimentServices, "HTTPRoute should have experiment services initially")
+
+	stableWeight = int32(100)
+	canaryWeight = int32(0)
+	filteredBackendRefs := []gatewayv1.HTTPBackendRef{}
+
+	for _, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
+		serviceName := string(backendRef.Name)
+
+		if serviceName == stableService {
+			backendRef.Weight = &stableWeight
+			filteredBackendRefs = append(filteredBackendRefs, backendRef)
+		} else if serviceName == canaryService {
+			backendRef.Weight = &canaryWeight
+			filteredBackendRefs = append(filteredBackendRefs, backendRef)
+		}
+	}
+
+	httpRoute.Spec.Rules[ruleIdx].BackendRefs = filteredBackendRefs
+
+	assert.Len(t, httpRoute.Spec.Rules[0].BackendRefs, 2, "Should only have stable and canary services after cleanup")
+	assert.Equal(t, int32(100), *httpRoute.Spec.Rules[0].BackendRefs[0].Weight, "Stable weight should be reset to 100%")
+	assert.Equal(t, int32(0), *httpRoute.Spec.Rules[0].BackendRefs[1].Weight, "Canary weight should remain at 0%")
+
+	hasExperimentServices = false
+	for _, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
+		serviceName := string(backendRef.Name)
+		if serviceName != stableService && serviceName != canaryService {
+			hasExperimentServices = true
+			break
+		}
+	}
+	assert.False(t, hasExperimentServices, "HTTPRoute should not have experiment services after cleanup")
+}

--- a/pkg/plugin/httproute.go
+++ b/pkg/plugin/httproute.go
@@ -52,6 +52,10 @@ func (r *RpcPlugin) setHTTPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight 
 	for _, ref := range stableBackendRefs {
 		ref.Weight = &restWeight
 	}
+	err = HandleExperiment(ctx, r.Clientset, r.GatewayAPIClientset, r.LogCtx, rollout, httpRoute)
+	if err != nil {
+		r.LogCtx.Error(err, "Failed to handle experiment services")
+	}
 	updatedHTTPRoute, err := httpRouteClient.Update(ctx, httpRoute, metav1.UpdateOptions{})
 	if r.IsTest {
 		r.UpdatedHTTPRouteMock = updatedHTTPRoute

--- a/pkg/plugin/httproute.go
+++ b/pkg/plugin/httproute.go
@@ -17,7 +17,7 @@ const (
 	HTTPConfigMapKey = "httpManagedRoutes"
 )
 
-func (r *RpcPlugin) setHTTPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight int32, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
+func (r *RpcPlugin) setHTTPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight int32, additionalDestinations []v1alpha1.WeightDestination, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
 	ctx := context.TODO()
 	httpRouteClient := r.HTTPRouteClient
 	if !r.IsTest {
@@ -52,7 +52,7 @@ func (r *RpcPlugin) setHTTPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight 
 	for _, ref := range stableBackendRefs {
 		ref.Weight = &restWeight
 	}
-	err = HandleExperiment(ctx, r.Clientset, r.GatewayAPIClientset, r.LogCtx, rollout, httpRoute)
+	err = HandleExperiment(ctx, r.Clientset, r.GatewayAPIClientset, r.LogCtx, rollout, httpRoute, additionalDestinations)
 	if err != nil {
 		r.LogCtx.Error(err, "Failed to handle experiment services")
 	}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -78,7 +78,7 @@ func (r *RpcPlugin) SetWeight(rollout *v1alpha1.Rollout, desiredWeight int32, ad
 	r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls HTTPRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.HTTPRoutes)))
 	rpcError := forEachGatewayAPIRoute(gatewayAPIConfig.HTTPRoutes, func(route HTTPRoute) pluginTypes.RpcError {
 		gatewayAPIConfig.HTTPRoute = route.Name
-		return r.setHTTPRouteWeight(rollout, desiredWeight, gatewayAPIConfig)
+		return r.setHTTPRouteWeight(rollout, desiredWeight, additionalDestinations, gatewayAPIConfig)
 	})
 	if rpcError.HasError() {
 		return rpcError


### PR DESCRIPTION
This implementation handles adding experiment services to HTTPRoute when an experiment is active and removing them when the experiment is completed.

Addresses issue [#112](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/issues/112).

The plugin automatically:

Detects when an experiment is active in a rollout
Adjusts the stable service weight to accommodate experiment traffic
Adds experiment services to the HTTPRoute with appropriate weights
Removes experiment services when the experiment completes

The feature is to support "**Weighted Experiment Step with Traffic Routing with gateway API**" -  of https://argo-rollouts.readthedocs.io/en/stable/features/experiment/#weighted-experiment-step-with-traffic-routing