### PR TITLE
fix(grpc): dont remove HTTP managed routes on setGRPCHeaderRoute when match is nil

### DIFF
--- a/pkg/plugin/grpcroute.go
+++ b/pkg/plugin/grpcroute.go
@@ -71,7 +71,7 @@ func (r *RpcPlugin) setGRPCHeaderRoute(rollout *v1alpha1.Rollout, headerRouting 
 				Name: headerRouting.Name,
 			},
 		}
-		return r.removeHTTPManagedRoutes(managedRouteList, gatewayAPIConfig)
+		return r.removeGRPCManagedRoutes(managedRouteList, gatewayAPIConfig)
 	}
 	ctx := context.TODO()
 	grpcRouteClient := r.GRPCRouteClient


### PR DESCRIPTION
Fixes: #117

Speaks for itself, looks like there was a simple mistake when defining the GRPCRoute support that missed changing this function to the GRPC one.

We DO call the correct function in the actual RemoveManagedRoutes function in `plugin.go`, but when this was set to the HTTPRoute function in `grpc.go` it meant that rollouts got stuck when someone defined the step to explicitly remove the route instead of letting the rollout controller remove everything once fully promoted/aborted.

Steps like this will cause a rollout to hang without this fix in place:

```yaml
        - setHeaderRoute:
            match:
              - headerName: foo
                headerValue:
                  exact: bar
            name: my-route
...
        # will not work and will cause rollout to hang and throw error
        - setHeaderRoute:
            name: my-route
```