### PR TITLE
docs: fix installation via init containers example

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,11 +59,10 @@ controller:
           - cp /bin/rollouts-plugin-trafficrouter-gatewayapi /plugins
         volumeMounts:                                 
           - name: gwapi-plugin
-            mountPath: /plugins
-    trafficRouterPlugins:                             
-      trafficRouterPlugins: |-
-        - name: argoproj-labs/gatewayAPI
-          location: "file:///plugins/rollouts-plugin-trafficrouter-gatewayapi"  
+            mountPath: /plugins                           
+    trafficRouterPlugins:
+      - name: argoproj-labs/gatewayAPI
+        location: "file:///plugins/rollouts-plugin-trafficrouter-gatewayapi"  
     volumes:                                           
       - name: gwapi-plugin
         emptyDir: {}


### PR DESCRIPTION
Hey guys,

I noticed that the example given in the docs has an issue which causes the error below when deployed as-is:

```
Failed to init config: failed to unmarshal traffic router plugins while initializing: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal object into Go value of type []types.PluginItem
```

The fix I'm submitting works and is tested. I believe the issue was that the config key was repeated twice.