### PR TITLE
Header based routing filters

### DIFF
--- a/pkg/plugin/grpcroute.go
+++ b/pkg/plugin/grpcroute.go
@@ -130,6 +130,7 @@ func (r *RpcPlugin) setGRPCHeaderRoute(rollout *v1alpha1.Rollout, headerRouting 
 	}
 	grpcHeaderRouteRule := gatewayv1.GRPCRouteRule{
 		Matches: []gatewayv1.GRPCRouteMatch{},
+		Filters: []gatewayv1.GRPCRouteFilter{},
 		BackendRefs: []gatewayv1.GRPCBackendRef{
 			{
 				BackendRef: gatewayv1.BackendRef{
@@ -142,6 +143,13 @@ func (r *RpcPlugin) setGRPCHeaderRoute(rollout *v1alpha1.Rollout, headerRouting 
 				},
 			},
 		},
+	}
+
+	// Copy filters from original route
+	if grpcRouteRule.Filters != nil {
+		for i := 0; i < len(grpcRouteRule.Filters); i++ {
+			grpcHeaderRouteRule.Filters = append(grpcHeaderRouteRule.Filters, *grpcRouteRule.Filters[i].DeepCopy())
+		}
 	}
 	matchLength := len(grpcRouteRule.Matches)
 	if matchLength == 0 {

--- a/pkg/plugin/httproute.go
+++ b/pkg/plugin/httproute.go
@@ -134,6 +134,7 @@ func (r *RpcPlugin) setHTTPHeaderRoute(rollout *v1alpha1.Rollout, headerRouting 
 	}
 	httpHeaderRouteRule := gatewayv1.HTTPRouteRule{
 		Matches: []gatewayv1.HTTPRouteMatch{},
+		Filters: []gatewayv1.HTTPRouteFilter{},
 		BackendRefs: []gatewayv1.HTTPBackendRef{
 			{
 				BackendRef: gatewayv1.BackendRef{
@@ -147,6 +148,15 @@ func (r *RpcPlugin) setHTTPHeaderRoute(rollout *v1alpha1.Rollout, headerRouting 
 			},
 		},
 	}
+
+	// Copy filters from original route
+	if httpRouteRule.Filters != nil {
+		for i := 0; i < len(httpRouteRule.Filters); i++ {
+			httpHeaderRouteRule.Filters = append(httpHeaderRouteRule.Filters, *httpRouteRule.Filters[i].DeepCopy())
+		}
+	}
+
+	// Copy matches from original route
 	for i := 0; i < len(httpRouteRule.Matches); i++ {
 		httpHeaderRouteRule.Matches = append(httpHeaderRouteRule.Matches, gatewayv1.HTTPRouteMatch{
 			Path:        httpRouteRule.Matches[i].Path,
@@ -154,6 +164,7 @@ func (r *RpcPlugin) setHTTPHeaderRoute(rollout *v1alpha1.Rollout, headerRouting 
 			QueryParams: httpRouteRule.Matches[i].QueryParams,
 		})
 	}
+
 	httpRouteRuleList = append(httpRouteRuleList, httpHeaderRouteRule)
 	oldHTTPRuleList := httpRoute.Spec.Rules
 	httpRoute.Spec.Rules = httpRouteRuleList

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -222,6 +222,113 @@ func TestRunSuccessfully(t *testing.T) {
 		assert.Equal(t, prefixedHeaderValue, rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Matches[0].Headers[0].Value)
 		assert.Equal(t, headerValueType, *rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Matches[0].Headers[0].Type)
 	})
+	t.Run("SetGRPCHeaderRouteWithFilters", func(t *testing.T) {
+		// Create a GRPCRoute mock with filters
+		grpcRouteWithFilters := mocks.GRPCRouteObj
+		grpcRouteWithFilters.Spec.Rules[0].Filters = []gatewayv1.GRPCRouteFilter{
+			{
+				Type: gatewayv1.GRPCRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{
+						{
+							Name:  "X-Custom-Header",
+							Value: "custom-value",
+						},
+					},
+				},
+			},
+			{
+				Type: gatewayv1.GRPCRouteFilterResponseHeaderModifier,
+				ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{
+						{
+							Name:  "X-Response-Header",
+							Value: "response-value",
+						},
+					},
+				},
+			},
+		}
+
+		// Update the plugin's GRPCRouteClient with the new mock
+		rpcPluginImp.GRPCRouteClient = gwFake.NewSimpleClientset(&grpcRouteWithFilters).GatewayV1().GRPCRoutes(mocks.RolloutNamespace)
+
+		headerName := "X-Test"
+		headerValue := "test"
+		headerMatch := v1alpha1.StringMatch{
+			Prefix: headerValue,
+		}
+		headerRouting := v1alpha1.SetHeaderRoute{
+			Name: mocks.ManagedRouteName,
+			Match: []v1alpha1.HeaderRoutingMatch{
+				{
+					HeaderName:  headerName,
+					HeaderValue: &headerMatch,
+				},
+			},
+		}
+		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+			Namespace: mocks.RolloutNamespace,
+			GRPCRoute: mocks.GRPCRouteName,
+			ConfigMap: mocks.ConfigMapName,
+		})
+		err := pluginInstance.SetHeaderRoute(rollout, &headerRouting)
+
+		assert.Empty(t, err.Error())
+		// Verify that the new header route rule (index 1) has the same filters as the original route rule (index 0)
+		originalFilters := grpcRouteWithFilters.Spec.Rules[0].Filters
+		newRouteFilters := rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Filters
+
+		assert.Equal(t, len(originalFilters), len(newRouteFilters), "New route should have same number of filters as original")
+
+		// Verify first filter (RequestHeaderModifier)
+		assert.Equal(t, originalFilters[0].Type, newRouteFilters[0].Type)
+		assert.Equal(t, originalFilters[0].RequestHeaderModifier.Add[0].Name, newRouteFilters[0].RequestHeaderModifier.Add[0].Name)
+		assert.Equal(t, originalFilters[0].RequestHeaderModifier.Add[0].Value, newRouteFilters[0].RequestHeaderModifier.Add[0].Value)
+
+		// Verify second filter (ResponseHeaderModifier)
+		assert.Equal(t, originalFilters[1].Type, newRouteFilters[1].Type)
+		assert.Equal(t, originalFilters[1].ResponseHeaderModifier.Set[0].Name, newRouteFilters[1].ResponseHeaderModifier.Set[0].Name)
+		assert.Equal(t, originalFilters[1].ResponseHeaderModifier.Set[0].Value, newRouteFilters[1].ResponseHeaderModifier.Set[0].Value)
+	})
+	t.Run("SetGRPCHeaderRouteWithoutFilters", func(t *testing.T) {
+		// Create a GRPCRoute mock without filters (using the original mock which has no filters)
+		grpcRouteWithoutFilters := mocks.GRPCRouteObj
+		grpcRouteWithoutFilters.Spec.Rules[0].Filters = nil // Explicitly set to nil
+
+		// Update the plugin's GRPCRouteClient with the mock without filters
+		rpcPluginImp.GRPCRouteClient = gwFake.NewSimpleClientset(&grpcRouteWithoutFilters).GatewayV1().GRPCRoutes(mocks.RolloutNamespace)
+
+		headerName := "X-Test"
+		headerValue := "test"
+		headerMatch := v1alpha1.StringMatch{
+			Prefix: headerValue,
+		}
+		headerRouting := v1alpha1.SetHeaderRoute{
+			Name: mocks.ManagedRouteName,
+			Match: []v1alpha1.HeaderRoutingMatch{
+				{
+					HeaderName:  headerName,
+					HeaderValue: &headerMatch,
+				},
+			},
+		}
+		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+			Namespace: mocks.RolloutNamespace,
+			GRPCRoute: mocks.GRPCRouteName,
+			ConfigMap: mocks.ConfigMapName,
+		})
+		err := pluginInstance.SetHeaderRoute(rollout, &headerRouting)
+
+		assert.Empty(t, err.Error())
+		// Verify that the new header route rule (index 1) has no filters, same as the original route rule (index 0)
+		originalFilters := grpcRouteWithoutFilters.Spec.Rules[0].Filters
+		newRouteFilters := rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Filters
+
+		assert.Nil(t, originalFilters, "Original route should have no filters")
+		assert.Equal(t, len(originalFilters), len(newRouteFilters), "New route should have same number of filters as original (none)")
+		assert.Empty(t, newRouteFilters, "New route should have no filters when original has none")
+	})
 	t.Run("SetHTTPHeaderRouteWithFilters", func(t *testing.T) {
 		// Create an HTTPRoute mock with filters
 		httpRouteWithFilters := mocks.HTTPRouteObj

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -222,6 +222,113 @@ func TestRunSuccessfully(t *testing.T) {
 		assert.Equal(t, prefixedHeaderValue, rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Matches[0].Headers[0].Value)
 		assert.Equal(t, headerValueType, *rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Matches[0].Headers[0].Type)
 	})
+	t.Run("SetHTTPHeaderRouteWithFilters", func(t *testing.T) {
+		// Create an HTTPRoute mock with filters
+		httpRouteWithFilters := mocks.HTTPRouteObj
+		httpRouteWithFilters.Spec.Rules[0].Filters = []gatewayv1.HTTPRouteFilter{
+			{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{
+						{
+							Name:  "X-Custom-Header",
+							Value: "custom-value",
+						},
+					},
+				},
+			},
+			{
+				Type: gatewayv1.HTTPRouteFilterResponseHeaderModifier,
+				ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{
+						{
+							Name:  "X-Response-Header",
+							Value: "response-value",
+						},
+					},
+				},
+			},
+		}
+
+		// Update the plugin's HTTPRouteClient with the new mock
+		rpcPluginImp.HTTPRouteClient = gwFake.NewSimpleClientset(&httpRouteWithFilters).GatewayV1().HTTPRoutes(mocks.RolloutNamespace)
+
+		headerName := "X-Test"
+		headerValue := "test"
+		headerMatch := v1alpha1.StringMatch{
+			Prefix: headerValue,
+		}
+		headerRouting := v1alpha1.SetHeaderRoute{
+			Name: mocks.ManagedRouteName,
+			Match: []v1alpha1.HeaderRoutingMatch{
+				{
+					HeaderName:  headerName,
+					HeaderValue: &headerMatch,
+				},
+			},
+		}
+		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+			Namespace: mocks.RolloutNamespace,
+			HTTPRoute: mocks.HTTPRouteName,
+			ConfigMap: mocks.ConfigMapName,
+		})
+		err := pluginInstance.SetHeaderRoute(rollout, &headerRouting)
+
+		assert.Empty(t, err.Error())
+		// Verify that the new header route rule (index 1) has the same filters as the original route rule (index 0)
+		originalFilters := httpRouteWithFilters.Spec.Rules[0].Filters
+		newRouteFilters := rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Filters
+
+		assert.Equal(t, len(originalFilters), len(newRouteFilters), "New route should have same number of filters as original")
+
+		// Verify first filter (RequestHeaderModifier)
+		assert.Equal(t, originalFilters[0].Type, newRouteFilters[0].Type)
+		assert.Equal(t, originalFilters[0].RequestHeaderModifier.Add[0].Name, newRouteFilters[0].RequestHeaderModifier.Add[0].Name)
+		assert.Equal(t, originalFilters[0].RequestHeaderModifier.Add[0].Value, newRouteFilters[0].RequestHeaderModifier.Add[0].Value)
+
+		// Verify second filter (ResponseHeaderModifier)
+		assert.Equal(t, originalFilters[1].Type, newRouteFilters[1].Type)
+		assert.Equal(t, originalFilters[1].ResponseHeaderModifier.Set[0].Name, newRouteFilters[1].ResponseHeaderModifier.Set[0].Name)
+		assert.Equal(t, originalFilters[1].ResponseHeaderModifier.Set[0].Value, newRouteFilters[1].ResponseHeaderModifier.Set[0].Value)
+	})
+	t.Run("SetHTTPHeaderRouteWithoutFilters", func(t *testing.T) {
+		// Create an HTTPRoute mock without filters (using the original mock which has no filters)
+		httpRouteWithoutFilters := mocks.HTTPRouteObj
+		httpRouteWithoutFilters.Spec.Rules[0].Filters = nil // Explicitly set to nil
+
+		// Update the plugin's HTTPRouteClient with the mock without filters
+		rpcPluginImp.HTTPRouteClient = gwFake.NewSimpleClientset(&httpRouteWithoutFilters).GatewayV1().HTTPRoutes(mocks.RolloutNamespace)
+
+		headerName := "X-Test"
+		headerValue := "test"
+		headerMatch := v1alpha1.StringMatch{
+			Prefix: headerValue,
+		}
+		headerRouting := v1alpha1.SetHeaderRoute{
+			Name: mocks.ManagedRouteName,
+			Match: []v1alpha1.HeaderRoutingMatch{
+				{
+					HeaderName:  headerName,
+					HeaderValue: &headerMatch,
+				},
+			},
+		}
+		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+			Namespace: mocks.RolloutNamespace,
+			HTTPRoute: mocks.HTTPRouteName,
+			ConfigMap: mocks.ConfigMapName,
+		})
+		err := pluginInstance.SetHeaderRoute(rollout, &headerRouting)
+
+		assert.Empty(t, err.Error())
+		// Verify that the new header route rule (index 1) has no filters, same as the original route rule (index 0)
+		originalFilters := httpRouteWithoutFilters.Spec.Rules[0].Filters
+		newRouteFilters := rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Filters
+
+		assert.Nil(t, originalFilters, "Original route should have no filters")
+		assert.Equal(t, len(originalFilters), len(newRouteFilters), "New route should have same number of filters as original (none)")
+		assert.Empty(t, newRouteFilters, "New route should have no filters when original has none")
+	})
 	t.Run("RemoveHTTPManagedRoutes", func(t *testing.T) {
 		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
 			Namespace: mocks.RolloutNamespace,

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -23,6 +23,14 @@ const (
 	TCP_ROUTE_BASIC_PATH         = "./testdata/tcproute-basic.yml"
 	TCP_ROUTE_BASIC_ROLLOUT_PATH = "./testdata/single-tcproute-rollout.yml"
 
+	// HTTP Route filter test paths
+	HTTP_ROUTE_FILTERS_PATH         = "./testdata/httproute-filters.yml"
+	HTTP_ROUTE_FILTERS_ROLLOUT_PATH = "./testdata/single-httproute-filters-rollout.yml"
+
+	// GRPC Route filter test paths
+	GRPC_ROUTE_FILTERS_PATH         = "./testdata/grpcroute-filters.yml"
+	GRPC_ROUTE_FILTERS_ROLLOUT_PATH = "./testdata/single-grpcroute-filters-rollout.yml"
+
 	ROLLOUT_TEMPLATE_CONTAINERS_FIELD      = "spec.template.spec.containers"
 	ROLLOUT_TEMPLATE_FIRST_CONTAINER_FIELD = "spec.template.spec.containers.0"
 	NEW_IMAGE_FIELD_VALUE                  = "argoproj/rollouts-demo:green"

--- a/test/e2e/single_grpcRoute_filters_test.go
+++ b/test/e2e/single_grpcRoute_filters_test.go
@@ -1,4 +1,4 @@
-//go:build flaky
+//go:build !flaky
 
 package e2e
 

--- a/test/e2e/single_grpcRoute_filters_test.go
+++ b/test/e2e/single_grpcRoute_filters_test.go
@@ -1,0 +1,449 @@
+//go:build flaky
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/e2e-framework/klient/decoder"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestSingleGRPCRouteWithFilters(t *testing.T) {
+	feature := features.New("Single GRPCRoute with filters feature").Setup(
+		setupEnvironment,
+	).Setup(
+		setupSingleGRPCRouteFiltersEnv,
+	).Assess(
+		"Testing GRPCRoute filter preservation",
+		testSingleGRPCRouteFilters,
+	).Teardown(
+		teardownSingleGRPCRouteFiltersEnv,
+	).Feature()
+	_ = global.Test(t, feature)
+}
+
+func setupSingleGRPCRouteFiltersEnv(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+	var grpcRoute gatewayv1.GRPCRoute
+	var rollout v1alpha1.Rollout
+	clusterResources := config.Client().Resources()
+	resourcesMap := map[string]*unstructured.Unstructured{}
+	ctx = context.WithValue(ctx, RESOURCES_MAP_KEY, resourcesMap)
+
+	grpcRouteFile, err := os.Open(GRPC_ROUTE_FILTERS_PATH)
+	if err != nil {
+		logrus.Errorf("file %q opening was failed: %s", GRPC_ROUTE_FILTERS_PATH, err)
+		t.Error()
+		return ctx
+	}
+	defer grpcRouteFile.Close()
+	logrus.Infof("file %q was opened", GRPC_ROUTE_FILTERS_PATH)
+
+	rolloutFile, err := os.Open(GRPC_ROUTE_FILTERS_ROLLOUT_PATH)
+	if err != nil {
+		logrus.Errorf("file %q opening was failed: %s", GRPC_ROUTE_FILTERS_ROLLOUT_PATH, err)
+		t.Error()
+		return ctx
+	}
+	defer rolloutFile.Close()
+	logrus.Infof("file %q was opened", GRPC_ROUTE_FILTERS_ROLLOUT_PATH)
+
+	err = decoder.Decode(grpcRouteFile, &grpcRoute)
+	if err != nil {
+		logrus.Errorf("file %q decoding was failed: %s", GRPC_ROUTE_FILTERS_PATH, err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("file %q was decoded", GRPC_ROUTE_FILTERS_PATH)
+
+	err = decoder.Decode(rolloutFile, &rollout)
+	if err != nil {
+		logrus.Errorf("file %q decoding was failed: %s", GRPC_ROUTE_FILTERS_ROLLOUT_PATH, err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("file %q was decoded", GRPC_ROUTE_FILTERS_ROLLOUT_PATH)
+
+	grpcRouteObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&grpcRoute)
+	if err != nil {
+		logrus.Errorf("grpcRoute %q converting to unstructured was failed: %s", grpcRoute.GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("grpcRoute %q was converted to unstructured", grpcRoute.GetName())
+	resourcesMap[GRPC_ROUTE_KEY] = &unstructured.Unstructured{
+		Object: grpcRouteObject,
+	}
+
+	rolloutObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&rollout)
+	if err != nil {
+		logrus.Errorf("rollout %q converting to unstructured was failed: %s", rollout.GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was converted to unstructured", rollout.GetName())
+	unstructured.RemoveNestedField(rolloutObject, "spec", "template", "metadata", "creationTimestamp")
+	resourcesMap[ROLLOUT_KEY] = &unstructured.Unstructured{
+		Object: rolloutObject,
+	}
+
+	err = clusterResources.Create(ctx, resourcesMap[GRPC_ROUTE_KEY])
+	if err != nil {
+		logrus.Errorf("grpcRoute %q creation was failed: %s", resourcesMap[GRPC_ROUTE_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("grpcRoute %q was created", resourcesMap[GRPC_ROUTE_KEY].GetName())
+
+	err = clusterResources.Create(ctx, resourcesMap[ROLLOUT_KEY])
+	if err != nil {
+		logrus.Errorf("rollout %q creation was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was created", resourcesMap[ROLLOUT_KEY].GetName())
+
+	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for grpcRoute %q to connect with rollout %q (expecting canary weight: %d)", resourcesMap[GRPC_ROUTE_KEY].GetName(), resourcesMap[ROLLOUT_KEY].GetName(), FIRST_CANARY_ROUTE_WEIGHT)
+	err = wait.For(
+		waitCondition.ResourceMatch(
+			resourcesMap[GRPC_ROUTE_KEY],
+			getMatchGRPCRouteFetcher(t, FIRST_CANARY_ROUTE_WEIGHT),
+		),
+		wait.WithTimeout(MEDIUM_PERIOD),
+		wait.WithInterval(SHORT_PERIOD),
+	)
+	if err != nil {
+		logrus.Errorf("checking grpcRoute %q connection with rollout %q was failed: %s", resourcesMap[GRPC_ROUTE_KEY].GetName(), resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("grpcRoute %q connected with rollout %q", resourcesMap[GRPC_ROUTE_KEY].GetName(), resourcesMap[ROLLOUT_KEY].GetName())
+	return ctx
+}
+
+func testSingleGRPCRouteFilters(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+	clusterResources := config.Client().Resources()
+	resourcesMap, ok := ctx.Value(RESOURCES_MAP_KEY).(map[string]*unstructured.Unstructured)
+	if !ok {
+		logrus.Errorf("%q type assertion was failed", RESOURCES_MAP_KEY)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("%q was type asserted", RESOURCES_MAP_KEY)
+
+	grpcRouteName := resourcesMap[GRPC_ROUTE_KEY].GetName()
+
+	// Update rollout image to trigger progression through steps
+	containersObject, isFound, err := unstructured.NestedFieldNoCopy(resourcesMap[ROLLOUT_KEY].Object, strings.Split(ROLLOUT_TEMPLATE_CONTAINERS_FIELD, ".")...)
+	if !isFound {
+		logrus.Errorf("rollout %q field %q was not found", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_CONTAINERS_FIELD)
+		t.Error()
+		return ctx
+	}
+	if err != nil {
+		logrus.Errorf("getting rollout %q field %q was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_CONTAINERS_FIELD, err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q field %q was received", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_CONTAINERS_FIELD)
+
+	unstructuredContainerList, ok := containersObject.([]interface{})
+	if !ok {
+		logrus.Errorf("rollout %q field %q type assertion was failed", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_CONTAINERS_FIELD)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q field %q was type asserted", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_CONTAINERS_FIELD)
+
+	unstructuredContainer, ok := unstructuredContainerList[0].(map[string]interface{})
+	if !ok {
+		logrus.Errorf("rollout %q field %q type assertion was failed", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_FIRST_CONTAINER_FIELD)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q field %q was type asserted", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_FIRST_CONTAINER_FIELD)
+
+	unstructured.RemoveNestedField(resourcesMap[ROLLOUT_KEY].Object, "metadata", "resourceVersion")
+	unstructuredContainer["image"] = NEW_IMAGE_FIELD_VALUE
+	serializedRollout, err := json.Marshal(resourcesMap[ROLLOUT_KEY].Object)
+	if err != nil {
+		logrus.Errorf("rollout %q serializing was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was serialized", resourcesMap[ROLLOUT_KEY].GetName())
+
+	rolloutPatch := k8s.Patch{
+		PatchType: types.MergePatchType,
+		Data:      serializedRollout,
+	}
+	err = clusterResources.Patch(ctx, resourcesMap[ROLLOUT_KEY], rolloutPatch)
+	if err != nil {
+		logrus.Errorf("rollout %q updating was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was updated", resourcesMap[ROLLOUT_KEY].GetName())
+
+	// Wait for grpcRoute to update with header-based routing and verify filters are preserved
+	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for grpcRoute %q to update with header-based routing and canary weight %d", resourcesMap[GRPC_ROUTE_KEY].GetName(), LAST_CANARY_ROUTE_WEIGHT)
+	err = wait.For(
+		waitCondition.ResourceMatch(
+			resourcesMap[GRPC_ROUTE_KEY],
+			func(obj k8s.Object) bool {
+				unstructuredGRPCRoute, ok := obj.(*unstructured.Unstructured)
+				if !ok {
+					logrus.Error("k8s object type assertion was failed")
+					return false
+				}
+
+				// Check if we have 2 rules (original + header route)
+				rules, found, err := unstructured.NestedSlice(unstructuredGRPCRoute.Object, "spec", "rules")
+				if !found || err != nil {
+					return false
+				}
+
+				// Should have exactly 2 rules now (original + header-based)
+				return len(rules) == 2
+			},
+		),
+		wait.WithTimeout(LONG_PERIOD),
+		wait.WithInterval(SHORT_PERIOD),
+	)
+
+	if err != nil {
+		logrus.Errorf("grpcRoute %q did not create header-based routing: %s", grpcRouteName, err)
+		t.Errorf("grpcRoute %q did not create header-based routing: %s", grpcRouteName, err)
+		return ctx
+	}
+	logrus.Infof("grpcRoute %q created header-based routing", grpcRouteName)
+
+	// Verify that we have the original rule plus the header-based rule using unstructured access
+	rules, found, err := unstructured.NestedSlice(resourcesMap[GRPC_ROUTE_KEY].Object, "spec", "rules")
+	if !found {
+		logrus.Errorf("grpcRoute %q rules field was not found", grpcRouteName)
+		t.Errorf("grpcRoute %q rules field was not found", grpcRouteName)
+		return ctx
+	}
+	if err != nil {
+		logrus.Errorf("getting grpcRoute %q rules was failed: %s", grpcRouteName, err)
+		t.Errorf("getting grpcRoute %q rules was failed: %s", grpcRouteName, err)
+		return ctx
+	}
+
+	if len(rules) != 2 {
+		logrus.Errorf("grpcRoute %q should have 2 rules (original + header), but has %d", grpcRouteName, len(rules))
+		t.Errorf("grpcRoute %q should have 2 rules (original + header), but has %d", grpcRouteName, len(rules))
+		return ctx
+	}
+
+	originalRule, ok := rules[0].(map[string]interface{})
+	if !ok {
+		logrus.Errorf("grpcRoute %q original rule type assertion failed", grpcRouteName)
+		t.Errorf("grpcRoute %q original rule type assertion failed", grpcRouteName)
+		return ctx
+	}
+
+	headerRule, ok := rules[1].(map[string]interface{})
+	if !ok {
+		logrus.Errorf("grpcRoute %q header rule type assertion failed", grpcRouteName)
+		t.Errorf("grpcRoute %q header rule type assertion failed", grpcRouteName)
+		return ctx
+	}
+
+	// Verify original rule still has all filters
+	originalFilters, found, err := unstructured.NestedSlice(originalRule, "filters")
+	if !found {
+		logrus.Errorf("grpcRoute %q original rule filters field was not found", grpcRouteName)
+		t.Errorf("grpcRoute %q original rule filters field was not found", grpcRouteName)
+		return ctx
+	}
+	if err != nil {
+		logrus.Errorf("getting grpcRoute %q original rule filters was failed: %s", grpcRouteName, err)
+		t.Errorf("getting grpcRoute %q original rule filters was failed: %s", grpcRouteName, err)
+		return ctx
+	}
+
+	expectedFiltersCount := 3 // RequestHeaderModifier, ResponseHeaderModifier, RequestMirror
+	if len(originalFilters) != expectedFiltersCount {
+		logrus.Errorf("original rule should have %d filters, but has %d", expectedFiltersCount, len(originalFilters))
+		t.Errorf("original rule should have %d filters, but has %d", expectedFiltersCount, len(originalFilters))
+		return ctx
+	}
+
+	// Verify header rule has copied all filters from original rule
+	headerFilters, found, err := unstructured.NestedSlice(headerRule, "filters")
+	if !found {
+		logrus.Errorf("grpcRoute %q header rule filters field was not found", grpcRouteName)
+		t.Errorf("grpcRoute %q header rule filters field was not found", grpcRouteName)
+		return ctx
+	}
+	if err != nil {
+		logrus.Errorf("getting grpcRoute %q header rule filters was failed: %s", grpcRouteName, err)
+		t.Errorf("getting grpcRoute %q header rule filters was failed: %s", grpcRouteName, err)
+		return ctx
+	}
+
+	if len(headerFilters) != len(originalFilters) {
+		logrus.Errorf("header rule should have same number of filters as original (%d), but has %d", len(originalFilters), len(headerFilters))
+		t.Errorf("header rule should have same number of filters as original (%d), but has %d", len(originalFilters), len(headerFilters))
+		return ctx
+	}
+
+	// Verify specific filter types are preserved
+	filterTypes := make(map[string]bool)
+	for _, filter := range headerFilters {
+		filterMap, ok := filter.(map[string]interface{})
+		if !ok {
+			logrus.Errorf("grpcRoute %q header rule filter type assertion failed", grpcRouteName)
+			t.Errorf("grpcRoute %q header rule filter type assertion failed", grpcRouteName)
+			return ctx
+		}
+		filterType, found, err := unstructured.NestedString(filterMap, "type")
+		if !found || err != nil {
+			logrus.Errorf("grpcRoute %q header rule filter type not found or error: %v", grpcRouteName, err)
+			t.Errorf("grpcRoute %q header rule filter type not found or error: %v", grpcRouteName, err)
+			return ctx
+		}
+		filterTypes[filterType] = true
+	}
+
+	expectedTypes := []string{
+		"RequestHeaderModifier",
+		"ResponseHeaderModifier",
+		"RequestMirror",
+	}
+
+	for _, expectedType := range expectedTypes {
+		if !filterTypes[expectedType] {
+			logrus.Errorf("header rule is missing filter type: %s", expectedType)
+			t.Errorf("header rule is missing filter type: %s", expectedType)
+			return ctx
+		}
+	}
+
+	// Verify header route has the correct header match
+	headerMatches, found, err := unstructured.NestedSlice(headerRule, "matches")
+	if !found {
+		logrus.Errorf("grpcRoute %q header rule matches field was not found", grpcRouteName)
+		t.Errorf("grpcRoute %q header rule matches field was not found", grpcRouteName)
+		return ctx
+	}
+	if err != nil {
+		logrus.Errorf("getting grpcRoute %q header rule matches was failed: %s", grpcRouteName, err)
+		t.Errorf("getting grpcRoute %q header rule matches was failed: %s", grpcRouteName, err)
+		return ctx
+	}
+
+	if len(headerMatches) == 0 {
+		logrus.Errorf("header rule should have matches")
+		t.Errorf("header rule should have matches")
+		return ctx
+	}
+
+	firstMatch, ok := headerMatches[0].(map[string]interface{})
+	if !ok {
+		logrus.Errorf("grpcRoute %q header rule first match type assertion failed", grpcRouteName)
+		t.Errorf("grpcRoute %q header rule first match type assertion failed", grpcRouteName)
+		return ctx
+	}
+
+	headers, found, err := unstructured.NestedSlice(firstMatch, "headers")
+	if !found {
+		logrus.Errorf("grpcRoute %q header rule match headers field was not found", grpcRouteName)
+		t.Errorf("grpcRoute %q header rule match headers field was not found", grpcRouteName)
+		return ctx
+	}
+	if err != nil {
+		logrus.Errorf("getting grpcRoute %q header rule match headers was failed: %s", grpcRouteName, err)
+		t.Errorf("getting grpcRoute %q header rule match headers was failed: %s", grpcRouteName, err)
+		return ctx
+	}
+
+	if len(headers) == 0 {
+		logrus.Errorf("header rule match should have headers")
+		t.Errorf("header rule match should have headers")
+		return ctx
+	}
+
+	headerMatch, ok := headers[0].(map[string]interface{})
+	if !ok {
+		logrus.Errorf("grpcRoute %q header rule match header type assertion failed", grpcRouteName)
+		t.Errorf("grpcRoute %q header rule match header type assertion failed", grpcRouteName)
+		return ctx
+	}
+
+	headerName, found, err := unstructured.NestedString(headerMatch, "name")
+	if !found || err != nil {
+		logrus.Errorf("grpcRoute %q header match name not found or error: %v", grpcRouteName, err)
+		t.Errorf("grpcRoute %q header match name not found or error: %v", grpcRouteName, err)
+		return ctx
+	}
+
+	if headerName != "X-GRPC-Filter-Test" {
+		logrus.Errorf("header match name should be 'X-GRPC-Filter-Test', but is '%s'", headerName)
+		t.Errorf("header match name should be 'X-GRPC-Filter-Test', but is '%s'", headerName)
+		return ctx
+	}
+
+	headerValue, found, err := unstructured.NestedString(headerMatch, "value")
+	if !found || err != nil {
+		logrus.Errorf("grpcRoute %q header match value not found or error: %v", grpcRouteName, err)
+		t.Errorf("grpcRoute %q header match value not found or error: %v", grpcRouteName, err)
+		return ctx
+	}
+
+	if headerValue != "preserve-grpc-filters" {
+		logrus.Errorf("header match value should be 'preserve-grpc-filters', but is '%s'", headerValue)
+		t.Errorf("header match value should be 'preserve-grpc-filters', but is '%s'", headerValue)
+		return ctx
+	}
+
+	logrus.Infof("GRPCRoute filter preservation test passed successfully")
+	return ctx
+}
+
+func teardownSingleGRPCRouteFiltersEnv(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+	clusterResources := config.Client().Resources()
+	resourcesMap, ok := ctx.Value(RESOURCES_MAP_KEY).(map[string]*unstructured.Unstructured)
+	if !ok {
+		logrus.Errorf("%q type assertion was failed", RESOURCES_MAP_KEY)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("%q was type asserted", RESOURCES_MAP_KEY)
+
+	err := clusterResources.Delete(ctx, resourcesMap[ROLLOUT_KEY])
+	if err != nil {
+		logrus.Errorf("deleting rollout %q was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was deleted", resourcesMap[ROLLOUT_KEY].GetName())
+
+	err = clusterResources.Delete(ctx, resourcesMap[GRPC_ROUTE_KEY])
+	if err != nil {
+		logrus.Errorf("deleting grpcRoute %q was failed: %s", resourcesMap[GRPC_ROUTE_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("grpcRoute %q was deleted", resourcesMap[GRPC_ROUTE_KEY].GetName())
+
+	return ctx
+}

--- a/test/e2e/single_httpRoute_filters_test.go
+++ b/test/e2e/single_httpRoute_filters_test.go
@@ -1,4 +1,4 @@
-//go:build flaky
+//go:build !flaky
 
 package e2e
 

--- a/test/e2e/single_httpRoute_filters_test.go
+++ b/test/e2e/single_httpRoute_filters_test.go
@@ -1,0 +1,450 @@
+//go:build flaky
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/e2e-framework/klient/decoder"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestSingleHTTPRouteWithFilters(t *testing.T) {
+	feature := features.New("Single HTTPRoute with filters feature").Setup(
+		setupEnvironment,
+	).Setup(
+		setupSingleHTTPRouteFiltersEnv,
+	).Assess(
+		"Testing HTTPRoute filter preservation",
+		testSingleHTTPRouteFilters,
+	).Teardown(
+		teardownSingleHTTPRouteFiltersEnv,
+	).Feature()
+	_ = global.Test(t, feature)
+}
+
+func setupSingleHTTPRouteFiltersEnv(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+	var httpRoute gatewayv1.HTTPRoute
+	var rollout v1alpha1.Rollout
+	clusterResources := config.Client().Resources()
+	resourcesMap := map[string]*unstructured.Unstructured{}
+	ctx = context.WithValue(ctx, RESOURCES_MAP_KEY, resourcesMap)
+
+	httpRouteFile, err := os.Open(HTTP_ROUTE_FILTERS_PATH)
+	if err != nil {
+		logrus.Errorf("file %q opening was failed: %s", HTTP_ROUTE_FILTERS_PATH, err)
+		t.Error()
+		return ctx
+	}
+	defer httpRouteFile.Close()
+	logrus.Infof("file %q was opened", HTTP_ROUTE_FILTERS_PATH)
+
+	rolloutFile, err := os.Open(HTTP_ROUTE_FILTERS_ROLLOUT_PATH)
+	if err != nil {
+		logrus.Errorf("file %q opening was failed: %s", HTTP_ROUTE_FILTERS_ROLLOUT_PATH, err)
+		t.Error()
+		return ctx
+	}
+	defer rolloutFile.Close()
+	logrus.Infof("file %q was opened", HTTP_ROUTE_FILTERS_ROLLOUT_PATH)
+
+	err = decoder.Decode(httpRouteFile, &httpRoute)
+	if err != nil {
+		logrus.Errorf("file %q decoding was failed: %s", HTTP_ROUTE_FILTERS_PATH, err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("file %q was decoded", HTTP_ROUTE_FILTERS_PATH)
+
+	err = decoder.Decode(rolloutFile, &rollout)
+	if err != nil {
+		logrus.Errorf("file %q decoding was failed: %s", HTTP_ROUTE_FILTERS_ROLLOUT_PATH, err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("file %q was decoded", HTTP_ROUTE_FILTERS_ROLLOUT_PATH)
+
+	httpRouteObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&httpRoute)
+	if err != nil {
+		logrus.Errorf("httpRoute %q converting to unstructured was failed: %s", httpRoute.GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("httpRoute %q was converted to unstructured", httpRoute.GetName())
+	resourcesMap[HTTP_ROUTE_KEY] = &unstructured.Unstructured{
+		Object: httpRouteObject,
+	}
+
+	rolloutObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&rollout)
+	if err != nil {
+		logrus.Errorf("rollout %q converting to unstructured was failed: %s", rollout.GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was converted to unstructured", rollout.GetName())
+	unstructured.RemoveNestedField(rolloutObject, "spec", "template", "metadata", "creationTimestamp")
+	resourcesMap[ROLLOUT_KEY] = &unstructured.Unstructured{
+		Object: rolloutObject,
+	}
+
+	err = clusterResources.Create(ctx, resourcesMap[HTTP_ROUTE_KEY])
+	if err != nil {
+		logrus.Errorf("httpRoute %q creation was failed: %s", resourcesMap[HTTP_ROUTE_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("httpRoute %q was created", resourcesMap[HTTP_ROUTE_KEY].GetName())
+
+	err = clusterResources.Create(ctx, resourcesMap[ROLLOUT_KEY])
+	if err != nil {
+		logrus.Errorf("rollout %q creation was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was created", resourcesMap[ROLLOUT_KEY].GetName())
+
+	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for httpRoute %q to connect with rollout %q (expecting canary weight: %d)", resourcesMap[HTTP_ROUTE_KEY].GetName(), resourcesMap[ROLLOUT_KEY].GetName(), FIRST_CANARY_ROUTE_WEIGHT)
+	err = wait.For(
+		waitCondition.ResourceMatch(
+			resourcesMap[HTTP_ROUTE_KEY],
+			getMatchHTTPRouteFetcher(t, FIRST_CANARY_ROUTE_WEIGHT),
+		),
+		wait.WithTimeout(MEDIUM_PERIOD),
+		wait.WithInterval(SHORT_PERIOD),
+	)
+	if err != nil {
+		logrus.Errorf("checking httpRoute %q connection with rollout %q was failed: %s", resourcesMap[HTTP_ROUTE_KEY].GetName(), resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("httpRoute %q connected with rollout %q", resourcesMap[HTTP_ROUTE_KEY].GetName(), resourcesMap[ROLLOUT_KEY].GetName())
+	return ctx
+}
+
+func testSingleHTTPRouteFilters(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+	clusterResources := config.Client().Resources()
+	resourcesMap, ok := ctx.Value(RESOURCES_MAP_KEY).(map[string]*unstructured.Unstructured)
+	if !ok {
+		logrus.Errorf("%q type assertion was failed", RESOURCES_MAP_KEY)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("%q was type asserted", RESOURCES_MAP_KEY)
+
+	httpRouteName := resourcesMap[HTTP_ROUTE_KEY].GetName()
+
+	// Update rollout image to trigger progression through steps
+	containersObject, isFound, err := unstructured.NestedFieldNoCopy(resourcesMap[ROLLOUT_KEY].Object, strings.Split(ROLLOUT_TEMPLATE_CONTAINERS_FIELD, ".")...)
+	if !isFound {
+		logrus.Errorf("rollout %q field %q was not found", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_CONTAINERS_FIELD)
+		t.Error()
+		return ctx
+	}
+	if err != nil {
+		logrus.Errorf("getting rollout %q field %q was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_CONTAINERS_FIELD, err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q field %q was received", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_CONTAINERS_FIELD)
+
+	unstructuredContainerList, ok := containersObject.([]interface{})
+	if !ok {
+		logrus.Errorf("rollout %q field %q type assertion was failed", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_CONTAINERS_FIELD)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q field %q was type asserted", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_CONTAINERS_FIELD)
+
+	unstructuredContainer, ok := unstructuredContainerList[0].(map[string]interface{})
+	if !ok {
+		logrus.Errorf("rollout %q field %q type assertion was failed", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_FIRST_CONTAINER_FIELD)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q field %q was type asserted", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_FIRST_CONTAINER_FIELD)
+
+	unstructured.RemoveNestedField(resourcesMap[ROLLOUT_KEY].Object, "metadata", "resourceVersion")
+	unstructuredContainer["image"] = NEW_IMAGE_FIELD_VALUE
+	serializedRollout, err := json.Marshal(resourcesMap[ROLLOUT_KEY].Object)
+	if err != nil {
+		logrus.Errorf("rollout %q serializing was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was serialized", resourcesMap[ROLLOUT_KEY].GetName())
+
+	rolloutPatch := k8s.Patch{
+		PatchType: types.MergePatchType,
+		Data:      serializedRollout,
+	}
+	err = clusterResources.Patch(ctx, resourcesMap[ROLLOUT_KEY], rolloutPatch)
+	if err != nil {
+		logrus.Errorf("rollout %q updating was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was updated", resourcesMap[ROLLOUT_KEY].GetName())
+
+	// Wait for httpRoute to update with header-based routing and verify filters are preserved
+	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for httpRoute %q to update with header-based routing and canary weight %d", resourcesMap[HTTP_ROUTE_KEY].GetName(), LAST_CANARY_ROUTE_WEIGHT)
+	err = wait.For(
+		waitCondition.ResourceMatch(
+			resourcesMap[HTTP_ROUTE_KEY],
+			func(obj k8s.Object) bool {
+				unstructuredHTTPRoute, ok := obj.(*unstructured.Unstructured)
+				if !ok {
+					logrus.Error("k8s object type assertion was failed")
+					return false
+				}
+
+				// Check if we have 2 rules (original + header route)
+				rules, found, err := unstructured.NestedSlice(unstructuredHTTPRoute.Object, "spec", "rules")
+				if !found || err != nil {
+					return false
+				}
+
+				// Should have exactly 2 rules now (original + header-based)
+				return len(rules) == 2
+			},
+		),
+		wait.WithTimeout(LONG_PERIOD),
+		wait.WithInterval(SHORT_PERIOD),
+	)
+
+	if err != nil {
+		logrus.Errorf("httpRoute %q did not create header-based routing: %s", httpRouteName, err)
+		t.Errorf("httpRoute %q did not create header-based routing: %s", httpRouteName, err)
+		return ctx
+	}
+	logrus.Infof("httpRoute %q created header-based routing", httpRouteName)
+
+	// Verify that we have the original rule plus the header-based rule using unstructured access
+	rules, found, err := unstructured.NestedSlice(resourcesMap[HTTP_ROUTE_KEY].Object, "spec", "rules")
+	if !found {
+		logrus.Errorf("httpRoute %q rules field was not found", httpRouteName)
+		t.Errorf("httpRoute %q rules field was not found", httpRouteName)
+		return ctx
+	}
+	if err != nil {
+		logrus.Errorf("getting httpRoute %q rules was failed: %s", httpRouteName, err)
+		t.Errorf("getting httpRoute %q rules was failed: %s", httpRouteName, err)
+		return ctx
+	}
+
+	if len(rules) != 2 {
+		logrus.Errorf("httpRoute %q should have 2 rules (original + header), but has %d", httpRouteName, len(rules))
+		t.Errorf("httpRoute %q should have 2 rules (original + header), but has %d", httpRouteName, len(rules))
+		return ctx
+	}
+
+	originalRule, ok := rules[0].(map[string]interface{})
+	if !ok {
+		logrus.Errorf("httpRoute %q original rule type assertion failed", httpRouteName)
+		t.Errorf("httpRoute %q original rule type assertion failed", httpRouteName)
+		return ctx
+	}
+
+	headerRule, ok := rules[1].(map[string]interface{})
+	if !ok {
+		logrus.Errorf("httpRoute %q header rule type assertion failed", httpRouteName)
+		t.Errorf("httpRoute %q header rule type assertion failed", httpRouteName)
+		return ctx
+	}
+
+	// Verify original rule still has all filters
+	originalFilters, found, err := unstructured.NestedSlice(originalRule, "filters")
+	if !found {
+		logrus.Errorf("httpRoute %q original rule filters field was not found", httpRouteName)
+		t.Errorf("httpRoute %q original rule filters field was not found", httpRouteName)
+		return ctx
+	}
+	if err != nil {
+		logrus.Errorf("getting httpRoute %q original rule filters was failed: %s", httpRouteName, err)
+		t.Errorf("getting httpRoute %q original rule filters was failed: %s", httpRouteName, err)
+		return ctx
+	}
+
+	expectedFiltersCount := 4 // RequestHeaderModifier, ResponseHeaderModifier, RequestMirror, URLRewrite
+	if len(originalFilters) != expectedFiltersCount {
+		logrus.Errorf("original rule should have %d filters, but has %d", expectedFiltersCount, len(originalFilters))
+		t.Errorf("original rule should have %d filters, but has %d", expectedFiltersCount, len(originalFilters))
+		return ctx
+	}
+
+	// Verify header rule has copied all filters from original rule
+	headerFilters, found, err := unstructured.NestedSlice(headerRule, "filters")
+	if !found {
+		logrus.Errorf("httpRoute %q header rule filters field was not found", httpRouteName)
+		t.Errorf("httpRoute %q header rule filters field was not found", httpRouteName)
+		return ctx
+	}
+	if err != nil {
+		logrus.Errorf("getting httpRoute %q header rule filters was failed: %s", httpRouteName, err)
+		t.Errorf("getting httpRoute %q header rule filters was failed: %s", httpRouteName, err)
+		return ctx
+	}
+
+	if len(headerFilters) != len(originalFilters) {
+		logrus.Errorf("header rule should have same number of filters as original (%d), but has %d", len(originalFilters), len(headerFilters))
+		t.Errorf("header rule should have same number of filters as original (%d), but has %d", len(originalFilters), len(headerFilters))
+		return ctx
+	}
+
+	// Verify specific filter types are preserved
+	filterTypes := make(map[string]bool)
+	for _, filter := range headerFilters {
+		filterMap, ok := filter.(map[string]interface{})
+		if !ok {
+			logrus.Errorf("httpRoute %q header rule filter type assertion failed", httpRouteName)
+			t.Errorf("httpRoute %q header rule filter type assertion failed", httpRouteName)
+			return ctx
+		}
+		filterType, found, err := unstructured.NestedString(filterMap, "type")
+		if !found || err != nil {
+			logrus.Errorf("httpRoute %q header rule filter type not found or error: %v", httpRouteName, err)
+			t.Errorf("httpRoute %q header rule filter type not found or error: %v", httpRouteName, err)
+			return ctx
+		}
+		filterTypes[filterType] = true
+	}
+
+	expectedTypes := []string{
+		"RequestHeaderModifier",
+		"ResponseHeaderModifier",
+		"RequestMirror",
+		"URLRewrite",
+	}
+
+	for _, expectedType := range expectedTypes {
+		if !filterTypes[expectedType] {
+			logrus.Errorf("header rule is missing filter type: %s", expectedType)
+			t.Errorf("header rule is missing filter type: %s", expectedType)
+			return ctx
+		}
+	}
+
+	// Verify header route has the correct header match
+	headerMatches, found, err := unstructured.NestedSlice(headerRule, "matches")
+	if !found {
+		logrus.Errorf("httpRoute %q header rule matches field was not found", httpRouteName)
+		t.Errorf("httpRoute %q header rule matches field was not found", httpRouteName)
+		return ctx
+	}
+	if err != nil {
+		logrus.Errorf("getting httpRoute %q header rule matches was failed: %s", httpRouteName, err)
+		t.Errorf("getting httpRoute %q header rule matches was failed: %s", httpRouteName, err)
+		return ctx
+	}
+
+	if len(headerMatches) == 0 {
+		logrus.Errorf("header rule should have matches")
+		t.Errorf("header rule should have matches")
+		return ctx
+	}
+
+	firstMatch, ok := headerMatches[0].(map[string]interface{})
+	if !ok {
+		logrus.Errorf("httpRoute %q header rule first match type assertion failed", httpRouteName)
+		t.Errorf("httpRoute %q header rule first match type assertion failed", httpRouteName)
+		return ctx
+	}
+
+	headers, found, err := unstructured.NestedSlice(firstMatch, "headers")
+	if !found {
+		logrus.Errorf("httpRoute %q header rule match headers field was not found", httpRouteName)
+		t.Errorf("httpRoute %q header rule match headers field was not found", httpRouteName)
+		return ctx
+	}
+	if err != nil {
+		logrus.Errorf("getting httpRoute %q header rule match headers was failed: %s", httpRouteName, err)
+		t.Errorf("getting httpRoute %q header rule match headers was failed: %s", httpRouteName, err)
+		return ctx
+	}
+
+	if len(headers) == 0 {
+		logrus.Errorf("header rule match should have headers")
+		t.Errorf("header rule match should have headers")
+		return ctx
+	}
+
+	headerMatch, ok := headers[0].(map[string]interface{})
+	if !ok {
+		logrus.Errorf("httpRoute %q header rule match header type assertion failed", httpRouteName)
+		t.Errorf("httpRoute %q header rule match header type assertion failed", httpRouteName)
+		return ctx
+	}
+
+	headerName, found, err := unstructured.NestedString(headerMatch, "name")
+	if !found || err != nil {
+		logrus.Errorf("httpRoute %q header match name not found or error: %v", httpRouteName, err)
+		t.Errorf("httpRoute %q header match name not found or error: %v", httpRouteName, err)
+		return ctx
+	}
+
+	if headerName != "X-Filter-Test" {
+		logrus.Errorf("header match name should be 'X-Filter-Test', but is '%s'", headerName)
+		t.Errorf("header match name should be 'X-Filter-Test', but is '%s'", headerName)
+		return ctx
+	}
+
+	headerValue, found, err := unstructured.NestedString(headerMatch, "value")
+	if !found || err != nil {
+		logrus.Errorf("httpRoute %q header match value not found or error: %v", httpRouteName, err)
+		t.Errorf("httpRoute %q header match value not found or error: %v", httpRouteName, err)
+		return ctx
+	}
+
+	if headerValue != "preserve-filters" {
+		logrus.Errorf("header match value should be 'preserve-filters', but is '%s'", headerValue)
+		t.Errorf("header match value should be 'preserve-filters', but is '%s'", headerValue)
+		return ctx
+	}
+
+	logrus.Infof("HTTPRoute filter preservation test passed successfully")
+	return ctx
+}
+
+func teardownSingleHTTPRouteFiltersEnv(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+	clusterResources := config.Client().Resources()
+	resourcesMap, ok := ctx.Value(RESOURCES_MAP_KEY).(map[string]*unstructured.Unstructured)
+	if !ok {
+		logrus.Errorf("%q type assertion was failed", RESOURCES_MAP_KEY)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("%q was type asserted", RESOURCES_MAP_KEY)
+
+	err := clusterResources.Delete(ctx, resourcesMap[ROLLOUT_KEY])
+	if err != nil {
+		logrus.Errorf("deleting rollout %q was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was deleted", resourcesMap[ROLLOUT_KEY].GetName())
+
+	err = clusterResources.Delete(ctx, resourcesMap[HTTP_ROUTE_KEY])
+	if err != nil {
+		logrus.Errorf("deleting httpRoute %q was failed: %s", resourcesMap[HTTP_ROUTE_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("httpRoute %q was deleted", resourcesMap[HTTP_ROUTE_KEY].GetName())
+
+	return ctx
+}

--- a/test/e2e/testdata/grpcroute-filters.yml
+++ b/test/e2e/testdata/grpcroute-filters.yml
@@ -1,0 +1,51 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: grpcroute-filters
+  namespace: default
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      namespace: default
+  rules:
+    - matches:
+        - method:
+            service: rollouts.demo.Service
+      filters:
+        # RequestHeaderModifier - adds, sets, and removes request headers
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-GRPC-Request-Header
+                value: grpc-request-value
+              - name: X-Service-Environment
+                value: test
+            add:
+              - name: X-GRPC-Added-Header
+                value: grpc-added-value
+            remove:
+              - X-Remove-GRPC-Header
+        # ResponseHeaderModifier - adds, sets, and removes response headers  
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: X-GRPC-Response-Header
+                value: grpc-response-value
+              - name: X-GRPC-Server
+                value: gateway-api-grpc-test
+            add:
+              - name: X-GRPC-Response-Added
+                value: grpc-response-added-value
+            remove:
+              - grpc-status-details-bin
+        # RequestMirror - mirrors gRPC requests to another backend
+        - type: RequestMirror
+          requestMirror:
+            backendRef:
+              name: argo-rollouts-grpc-mirror-service
+              port: 80
+      backendRefs:
+        - name: argo-rollouts-stable-service
+          port: 80
+        - name: argo-rollouts-canary-service
+          port: 80

--- a/test/e2e/testdata/httproute-filters.yml
+++ b/test/e2e/testdata/httproute-filters.yml
@@ -1,0 +1,59 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-filters
+  namespace: default
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      namespace: default
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        # RequestHeaderModifier - adds, sets, and removes request headers
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Custom-Request-Header
+                value: custom-request-value
+              - name: X-Environment
+                value: test
+            add:
+              - name: X-Added-Header
+                value: added-value
+            remove:
+              - X-Remove-Me
+        # ResponseHeaderModifier - adds, sets, and removes response headers
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: X-Custom-Response-Header
+                value: custom-response-value
+              - name: X-Server
+                value: gateway-api-test
+            add:
+              - name: X-Response-Added
+                value: response-added-value
+            remove:
+              - Server
+        # RequestMirror - mirrors requests to another backend for testing/monitoring
+        - type: RequestMirror
+          requestMirror:
+            backendRef:
+              name: argo-rollouts-mirror-service
+              port: 80
+        # URLRewrite - rewrites the request URL path and hostname
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /api/v2
+            hostname: api.example.com
+      backendRefs:
+        - name: argo-rollouts-stable-service
+          port: 80
+        - name: argo-rollouts-canary-service
+          port: 80

--- a/test/e2e/testdata/single-grpcroute-filters-rollout.yml
+++ b/test/e2e/testdata/single-grpcroute-filters-rollout.yml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: grpcroute-filters-rollout
+  namespace: default
+spec:
+  replicas: 2
+  strategy:
+    canary:
+      canaryService: argo-rollouts-canary-service 
+      stableService: argo-rollouts-stable-service 
+      trafficRouting:
+        managedRoutes:
+        - name: grpc-filter-preservation-route
+        plugins:
+          argoproj-labs/gatewayAPI:
+            grpcRoutes:
+              - name: grpcroute-filters
+                useHeaderRoutes: true
+            namespace: default
+      steps:
+      - setWeight: 30
+      - setHeaderRoute:
+          name: grpc-filter-preservation-route
+          match:
+            - headerName: X-GRPC-Filter-Test
+              headerValue:
+                exact: preserve-grpc-filters  
+      - pause: {  }
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: rollouts-demo
+  template:
+    metadata:
+      labels:
+        app: rollouts-demo
+    spec:
+      containers:
+        - name: rollouts-demo
+          image: argoproj/rollouts-demo:red
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP

--- a/test/e2e/testdata/single-httproute-filters-rollout.yml
+++ b/test/e2e/testdata/single-httproute-filters-rollout.yml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: httproute-filters-rollout
+  namespace: default
+spec:
+  replicas: 2
+  strategy:
+    canary:
+      canaryService: argo-rollouts-canary-service 
+      stableService: argo-rollouts-stable-service 
+      trafficRouting:
+        managedRoutes:
+        - name: filter-preservation-route
+        plugins:
+          argoproj-labs/gatewayAPI:
+            httpRoutes:
+              - name: httproute-filters
+                useHeaderRoutes: true
+            namespace: default
+      steps:
+      - setWeight: 30
+      - setHeaderRoute:
+          name: filter-preservation-route
+          match:
+            - headerName: X-Filter-Test
+              headerValue:
+                exact: preserve-filters  
+      - pause: {  }
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: rollouts-demo
+  template:
+    metadata:
+      labels:
+        app: rollouts-demo
+    spec:
+      containers:
+        - name: rollouts-demo
+          image: argoproj/rollouts-demo:red
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP


### PR DESCRIPTION
When HTTP headers are used, clone all original filters/matches when creating the new route.

Fixes https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/issues/87