### PR TITLE
test: pause all rollouts so that e2e tests always find them

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
           make e2e-tests
 
   e2e-tests-flaky:
-    name: E2E tests running
+    name: E2E Flaky tests
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,28 @@ jobs:
         run: |
           make e2e-tests
 
+  e2e-tests-flaky:
+    name: E2E tests running
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+
+      - name: Set up Kind
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: "v0.23.0"
+          skipClusterCreation: true
+
+      - name: Checkout code
+        uses: actions/checkout@v3.1.0
+
+      - name: E2E tests running
+        run: |
+          make e2e-tests-flaky
+
   build:
     name: Build creation
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ sanity-check-e2e:
 run-e2e-tests: sanity-check-e2e
 	go test -v -timeout 5m -count=1 -run ${RUN} ./test/e2e/...
 
+# Flaky tests usually fail with GitHub actions. You should be able to run them locally though.
 .PHONY: e2e-tests-flaky
 e2e-tests-flaky: setup-e2e-cluster run-e2e-tests-flaky 
 ifeq (${CLUSTER_DELETE},true)

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,16 @@ sanity-check-e2e:
 run-e2e-tests: sanity-check-e2e
 	go test -v -timeout 5m -count=1 -run ${RUN} ./test/e2e/...
 
+.PHONY: e2e-tests-flaky
+e2e-tests-flaky: setup-e2e-cluster run-e2e-tests-flaky 
+ifeq (${CLUSTER_DELETE},true)
+	make clear-e2e-cluster
+endif
+
+.PHONY: run-e2e-tests-flaky 
+run-e2e-tests-flaky: sanity-check-e2e
+	go test -tags "flaky" -v -timeout 5m -count=1 -run ${RUN} ./test/e2e/... 
+
 .PHONY: clear-e2e-cluster
 clear-e2e-cluster:
 	kind delete cluster --name ${E2E_CLUSTER_NAME}

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -7,14 +7,21 @@ import (
 )
 
 const (
-	FIRST_HTTP_ROUTE_PATH                       = "./testdata/first-httproute.yml"
-	FIRST_GRPC_ROUTE_PATH                       = "./testdata/first-grpcroute.yml"
-	FIRST_TCP_ROUTE_PATH                        = "./testdata/first-tcproute.yml"
-	SINGLE_HTTP_ROUTE_ROLLOUT_PATH              = "./testdata/single-httproute-rollout.yml"
-	SINGLE_GRPC_ROUTE_ROLLOUT_PATH              = "./testdata/single-grpcroute-rollout.yml"
-	SINGLE_HEADER_BASED_HTTP_ROUTE_ROLLOUT_PATH = "./testdata/single-header-based-httproute-rollout.yml"
-	SINGLE_HEADER_BASED_GRPC_ROUTE_ROLLOUT_PATH = "./testdata/single-header-based-grpcroute-rollout.yml"
-	SINGLE_TCP_ROUTE_ROLLOUT_PATH               = "./testdata/single-tcproute-rollout.yml"
+	// HTTP Route test paths
+	HTTP_ROUTE_BASIC_PATH          = "./testdata/httproute-basic.yml"
+	HTTP_ROUTE_HEADER_PATH         = "./testdata/httproute-header.yml"
+	HTTP_ROUTE_BASIC_ROLLOUT_PATH  = "./testdata/single-httproute-rollout.yml"
+	HTTP_ROUTE_HEADER_ROLLOUT_PATH = "./testdata/single-header-based-httproute-rollout.yml"
+
+	// GRPC Route test paths
+	GRPC_ROUTE_BASIC_PATH          = "./testdata/grpcroute-basic.yml"
+	GRPC_ROUTE_HEADER_PATH         = "./testdata/grpcroute-header.yml"
+	GRPC_ROUTE_BASIC_ROLLOUT_PATH  = "./testdata/single-grpcroute-rollout.yml"
+	GRPC_ROUTE_HEADER_ROLLOUT_PATH = "./testdata/single-header-based-grpcroute-rollout.yml"
+
+	// TCP Route test paths
+	TCP_ROUTE_BASIC_PATH         = "./testdata/tcproute-basic.yml"
+	TCP_ROUTE_BASIC_ROLLOUT_PATH = "./testdata/single-tcproute-rollout.yml"
 
 	ROLLOUT_TEMPLATE_CONTAINERS_FIELD      = "spec.template.spec.containers"
 	ROLLOUT_TEMPLATE_FIRST_CONTAINER_FIELD = "spec.template.spec.containers.0"

--- a/test/e2e/single_grpcroute_test.go
+++ b/test/e2e/single_grpcroute_test.go
@@ -107,6 +107,7 @@ func setupSingleGRPCRouteEnv(ctx context.Context, t *testing.T, config *envconf.
 	}
 	logrus.Infof("rollout %q was created", resourcesMap[ROLLOUT_KEY].GetName())
 	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for grpcRoute %q to connect with rollout %q (expecting canary weight: %d)", resourcesMap[GRPC_ROUTE_KEY].GetName(), resourcesMap[ROLLOUT_KEY].GetName(), FIRST_CANARY_ROUTE_WEIGHT)
 	err = wait.For(
 		waitCondition.ResourceMatch(
 			resourcesMap[GRPC_ROUTE_KEY],
@@ -180,6 +181,7 @@ func testSingleGRPCRoute(ctx context.Context, t *testing.T, config *envconf.Conf
 	}
 	logrus.Infof("rollout %q was updated", resourcesMap[ROLLOUT_KEY].GetName())
 	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for grpcRoute %q to update canary weight to %d after rollout image change", resourcesMap[GRPC_ROUTE_KEY].GetName(), LAST_CANARY_ROUTE_WEIGHT)
 	err = wait.For(
 		waitCondition.ResourceMatch(
 			resourcesMap[GRPC_ROUTE_KEY],
@@ -232,14 +234,14 @@ func getMatchGRPCRouteFetcher(t *testing.T, targetWeight int32) func(k8s.Object)
 			t.Error()
 			return false
 		}
-		logrus.Info("k8s object was type asserted")
+		// logrus.Info("k8s object was type asserted")
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredGRPCRoute.Object, &grpcRoute)
 		if err != nil {
 			logrus.Errorf("conversation from unstructured grpcRoute %q to the typed grpcRoute was failed", unstructuredGRPCRoute.GetName())
 			t.Error()
 			return false
 		}
-		logrus.Infof("unstructured grpcRoute %q was converted to the typed grpcRoute", grpcRoute.GetName())
+		// logrus.Infof("Looking for grpcRoute %q to reach weight %d", grpcRoute.GetName(), targetWeight)
 		return *grpcRoute.Spec.Rules[ROLLOUT_ROUTE_RULE_INDEX].BackendRefs[CANARY_BACKEND_REF_INDEX].Weight == targetWeight
 	}
 }

--- a/test/e2e/single_grpcroute_test.go
+++ b/test/e2e/single_grpcroute_test.go
@@ -1,3 +1,5 @@
+//go:build !flaky
+
 package e2e
 
 import (
@@ -223,25 +225,4 @@ func teardownSingleGRPCRouteEnv(ctx context.Context, t *testing.T, config *envco
 	}
 	logrus.Infof("grpcRoute %q was deleted", resourcesMap[GRPC_ROUTE_KEY].GetName())
 	return ctx
-}
-
-func getMatchGRPCRouteFetcher(t *testing.T, targetWeight int32) func(k8s.Object) bool {
-	return func(obj k8s.Object) bool {
-		var grpcRoute v1alpha2.GRPCRoute
-		unstructuredGRPCRoute, ok := obj.(*unstructured.Unstructured)
-		if !ok {
-			logrus.Error("k8s object type assertion was failed")
-			t.Error()
-			return false
-		}
-		// logrus.Info("k8s object was type asserted")
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredGRPCRoute.Object, &grpcRoute)
-		if err != nil {
-			logrus.Errorf("conversation from unstructured grpcRoute %q to the typed grpcRoute was failed", unstructuredGRPCRoute.GetName())
-			t.Error()
-			return false
-		}
-		// logrus.Infof("Looking for grpcRoute %q to reach weight %d", grpcRoute.GetName(), targetWeight)
-		return *grpcRoute.Spec.Rules[ROLLOUT_ROUTE_RULE_INDEX].BackendRefs[CANARY_BACKEND_REF_INDEX].Weight == targetWeight
-	}
 }

--- a/test/e2e/single_grpcroute_test.go
+++ b/test/e2e/single_grpcroute_test.go
@@ -41,36 +41,36 @@ func setupSingleGRPCRouteEnv(ctx context.Context, t *testing.T, config *envconf.
 	clusterResources := config.Client().Resources()
 	resourcesMap := map[string]*unstructured.Unstructured{}
 	ctx = context.WithValue(ctx, RESOURCES_MAP_KEY, resourcesMap)
-	firstGRPCRouteFile, err := os.Open(FIRST_GRPC_ROUTE_PATH)
+	firstGRPCRouteFile, err := os.Open(GRPC_ROUTE_BASIC_PATH)
 	if err != nil {
-		logrus.Errorf("file %q openning was failed: %s", FIRST_GRPC_ROUTE_PATH, err)
+		logrus.Errorf("file %q openning was failed: %s", GRPC_ROUTE_BASIC_PATH, err)
 		t.Error()
 		return ctx
 	}
 	defer firstGRPCRouteFile.Close()
-	logrus.Infof("file %q was opened", FIRST_GRPC_ROUTE_PATH)
-	rolloutFile, err := os.Open(SINGLE_GRPC_ROUTE_ROLLOUT_PATH)
+	logrus.Infof("file %q was opened", GRPC_ROUTE_BASIC_PATH)
+	rolloutFile, err := os.Open(GRPC_ROUTE_BASIC_ROLLOUT_PATH)
 	if err != nil {
-		logrus.Errorf("file %q openning was failed: %s", SINGLE_GRPC_ROUTE_ROLLOUT_PATH, err)
+		logrus.Errorf("file %q openning was failed: %s", GRPC_ROUTE_BASIC_ROLLOUT_PATH, err)
 		t.Error()
 		return ctx
 	}
 	defer rolloutFile.Close()
-	logrus.Infof("file %q was opened", SINGLE_GRPC_ROUTE_ROLLOUT_PATH)
+	logrus.Infof("file %q was opened", GRPC_ROUTE_BASIC_ROLLOUT_PATH)
 	err = decoder.Decode(firstGRPCRouteFile, &grpcRoute)
 	if err != nil {
-		logrus.Errorf("file %q decoding was failed: %s", FIRST_GRPC_ROUTE_PATH, err)
+		logrus.Errorf("file %q decoding was failed: %s", GRPC_ROUTE_BASIC_PATH, err)
 		t.Error()
 		return ctx
 	}
-	logrus.Infof("file %q was decoded", FIRST_GRPC_ROUTE_PATH)
+	logrus.Infof("file %q was decoded", GRPC_ROUTE_BASIC_PATH)
 	err = decoder.Decode(rolloutFile, &rollout)
 	if err != nil {
-		logrus.Errorf("file %q decoding was failed: %s", SINGLE_GRPC_ROUTE_ROLLOUT_PATH, err)
+		logrus.Errorf("file %q decoding was failed: %s", GRPC_ROUTE_BASIC_ROLLOUT_PATH, err)
 		t.Error()
 		return ctx
 	}
-	logrus.Infof("file %q was decoded", SINGLE_GRPC_ROUTE_ROLLOUT_PATH)
+	logrus.Infof("file %q was decoded", GRPC_ROUTE_BASIC_ROLLOUT_PATH)
 	grpcRouteObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&grpcRoute)
 	if err != nil {
 		logrus.Errorf("grpcRoute %q converting to unstructured was failed: %s", grpcRoute.GetName(), err)

--- a/test/e2e/single_grpcroute_test.go
+++ b/test/e2e/single_grpcroute_test.go
@@ -191,7 +191,7 @@ func testSingleGRPCRoute(ctx context.Context, t *testing.T, config *envconf.Conf
 		wait.WithInterval(SHORT_PERIOD),
 	)
 	if err != nil {
-		logrus.Errorf("grpcRoute %q updation was failed: %s", resourcesMap[GRPC_ROUTE_KEY].GetName(), err)
+		logrus.Errorf("grpcRoute %q updating failed: %s", resourcesMap[GRPC_ROUTE_KEY].GetName(), err)
 		t.Error()
 		return ctx
 	}

--- a/test/e2e/single_header_based_grpcroute_test.go
+++ b/test/e2e/single_header_based_grpcroute_test.go
@@ -107,6 +107,7 @@ func setupSingleHeaderBasedGRPCRouteEnv(ctx context.Context, t *testing.T, confi
 	}
 	logrus.Infof("rollout %q was created", resourcesMap[ROLLOUT_KEY].GetName())
 	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for grpcRoute %q to connect with rollout %q (expecting canary weight: %d)", resourcesMap[GRPC_ROUTE_KEY].GetName(), resourcesMap[ROLLOUT_KEY].GetName(), FIRST_CANARY_ROUTE_WEIGHT)
 	err = wait.For(
 		waitCondition.ResourceMatch(
 			resourcesMap[GRPC_ROUTE_KEY],
@@ -180,6 +181,7 @@ func testSingleHeaderBasedGRPCRoute(ctx context.Context, t *testing.T, config *e
 	}
 	logrus.Infof("rollout %q was updated", resourcesMap[ROLLOUT_KEY].GetName())
 	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for grpcRoute %q to update with header-based routing and canary weight %d", resourcesMap[GRPC_ROUTE_KEY].GetName(), LAST_CANARY_ROUTE_WEIGHT)
 	err = wait.For(
 		waitCondition.ResourceMatch(
 			resourcesMap[GRPC_ROUTE_KEY],
@@ -198,6 +200,7 @@ func testSingleHeaderBasedGRPCRoute(ctx context.Context, t *testing.T, config *e
 		return ctx
 	}
 	logrus.Infof("grpcRoute %q was updated", resourcesMap[GRPC_ROUTE_KEY].GetName())
+	logrus.Infof("waiting for grpcRoute %q to clean up header-based routing and reset canary weight to %d", resourcesMap[GRPC_ROUTE_KEY].GetName(), FIRST_CANARY_ROUTE_WEIGHT)
 	err = wait.For(
 		waitCondition.ResourceMatch(
 			resourcesMap[GRPC_ROUTE_KEY],
@@ -254,14 +257,14 @@ func getMatchHeaderBasedGRPCRouteFetcher(t *testing.T, targetWeight int32, targe
 			t.Error()
 			return false
 		}
-		logrus.Info("k8s object was type asserted")
+		// logrus.Info("k8s object was type asserted")
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredGRPCRoute.Object, &grpcRoute)
 		if err != nil {
 			logrus.Errorf("conversation from unstructured grpcRoute %q to the typed grpcRoute was failed", unstructuredGRPCRoute.GetName())
 			t.Error()
 			return false
 		}
-		logrus.Infof("unstructured grpcRoute %q was converted to the typed grpcRoute", grpcRoute.GetName())
+		// logrus.Infof("unstructured grpcRoute %q was converted to the typed grpcRoute", grpcRoute.GetName())
 		rules := grpcRoute.Spec.Rules
 		if targetHeaderBasedRouteValue.Type == nil {
 			return len(rules) == LAST_HEADER_BASED_RULES_LENGTH &&

--- a/test/e2e/single_header_based_grpcroute_test.go
+++ b/test/e2e/single_header_based_grpcroute_test.go
@@ -1,3 +1,5 @@
+//go:build flaky
+
 package e2e
 
 import (
@@ -340,25 +342,4 @@ func getMatchHeaderBasedGRPCRouteFetcher(t *testing.T, targetWeight int32, targe
 
 func isHeaderBasedGRPCRouteValuesEqual(first, second gatewayv1.GRPCHeaderMatch) bool {
 	return first.Name == second.Name && *first.Type == *second.Type && first.Value == second.Value
-}
-
-func getRolloutHealthyFetcher(t *testing.T) func(k8s.Object) bool {
-	return func(obj k8s.Object) bool {
-		var rollout v1alpha1.Rollout
-		unstructuredRollout, ok := obj.(*unstructured.Unstructured)
-		if !ok {
-			logrus.Error("k8s rollout object type assertion was failed")
-			t.Error()
-			return false
-		}
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredRollout.Object, &rollout)
-		if err != nil {
-			logrus.Errorf("conversation from unstructured rollout %q to the typed rollout was failed", unstructuredRollout.GetName())
-			t.Error()
-			return false
-		}
-		// Check if rollout is healthy (completed successfully)
-		// A rollout is considered finished when its phase is "Healthy"
-		return rollout.Status.Phase == "Healthy"
-	}
 }

--- a/test/e2e/single_header_based_grpcroute_test.go
+++ b/test/e2e/single_header_based_grpcroute_test.go
@@ -41,36 +41,36 @@ func setupSingleHeaderBasedGRPCRouteEnv(ctx context.Context, t *testing.T, confi
 	clusterResources := config.Client().Resources()
 	resourcesMap := map[string]*unstructured.Unstructured{}
 	ctx = context.WithValue(ctx, RESOURCES_MAP_KEY, resourcesMap)
-	firstGRPCRouteFile, err := os.Open(FIRST_GRPC_ROUTE_PATH)
+	firstGRPCRouteFile, err := os.Open(GRPC_ROUTE_HEADER_PATH)
 	if err != nil {
-		logrus.Errorf("file %q openning was failed: %s", FIRST_GRPC_ROUTE_PATH, err)
+		logrus.Errorf("file %q openning was failed: %s", GRPC_ROUTE_HEADER_PATH, err)
 		t.Error()
 		return ctx
 	}
 	defer firstGRPCRouteFile.Close()
-	logrus.Infof("file %q was opened", FIRST_GRPC_ROUTE_PATH)
-	rolloutFile, err := os.Open(SINGLE_HEADER_BASED_GRPC_ROUTE_ROLLOUT_PATH)
+	logrus.Infof("file %q was opened", GRPC_ROUTE_HEADER_PATH)
+	rolloutFile, err := os.Open(GRPC_ROUTE_HEADER_ROLLOUT_PATH)
 	if err != nil {
-		logrus.Errorf("file %q openning was failed: %s", SINGLE_HEADER_BASED_GRPC_ROUTE_ROLLOUT_PATH, err)
+		logrus.Errorf("file %q openning was failed: %s", GRPC_ROUTE_HEADER_ROLLOUT_PATH, err)
 		t.Error()
 		return ctx
 	}
 	defer rolloutFile.Close()
-	logrus.Infof("file %q was opened", SINGLE_HEADER_BASED_GRPC_ROUTE_ROLLOUT_PATH)
+	logrus.Infof("file %q was opened", GRPC_ROUTE_HEADER_ROLLOUT_PATH)
 	err = decoder.Decode(firstGRPCRouteFile, &grpcRoute)
 	if err != nil {
-		logrus.Errorf("file %q decoding was failed: %s", FIRST_GRPC_ROUTE_PATH, err)
+		logrus.Errorf("file %q decoding was failed: %s", GRPC_ROUTE_HEADER_PATH, err)
 		t.Error()
 		return ctx
 	}
-	logrus.Infof("file %q was decoded", FIRST_GRPC_ROUTE_PATH)
+	logrus.Infof("file %q was decoded", GRPC_ROUTE_HEADER_PATH)
 	err = decoder.Decode(rolloutFile, &rollout)
 	if err != nil {
-		logrus.Errorf("file %q decoding was failed: %s", SINGLE_HEADER_BASED_GRPC_ROUTE_ROLLOUT_PATH, err)
+		logrus.Errorf("file %q decoding was failed: %s", GRPC_ROUTE_HEADER_ROLLOUT_PATH, err)
 		t.Error()
 		return ctx
 	}
-	logrus.Infof("file %q was decoded", SINGLE_HEADER_BASED_GRPC_ROUTE_ROLLOUT_PATH)
+	logrus.Infof("file %q was decoded", GRPC_ROUTE_HEADER_ROLLOUT_PATH)
 	grpcRouteObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&grpcRoute)
 	if err != nil {
 		logrus.Errorf("grpcRoute %q converting to unstructured was failed: %s", grpcRoute.GetName(), err)

--- a/test/e2e/single_header_based_grpcroute_test.go
+++ b/test/e2e/single_header_based_grpcroute_test.go
@@ -343,3 +343,24 @@ func getMatchHeaderBasedGRPCRouteFetcher(t *testing.T, targetWeight int32, targe
 func isHeaderBasedGRPCRouteValuesEqual(first, second gatewayv1.GRPCHeaderMatch) bool {
 	return first.Name == second.Name && *first.Type == *second.Type && first.Value == second.Value
 }
+
+func getRolloutHealthyFetcher(t *testing.T) func(k8s.Object) bool {
+	return func(obj k8s.Object) bool {
+		var rollout v1alpha1.Rollout
+		unstructuredRollout, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			logrus.Error("k8s rollout object type assertion was failed")
+			t.Error()
+			return false
+		}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredRollout.Object, &rollout)
+		if err != nil {
+			logrus.Errorf("conversation from unstructured rollout %q to the typed rollout was failed", unstructuredRollout.GetName())
+			t.Error()
+			return false
+		}
+		// Check if rollout is healthy (completed successfully)
+		// A rollout is considered finished when its phase is "Healthy"
+		return rollout.Status.Phase == "Healthy"
+	}
+}

--- a/test/e2e/single_header_based_grpcroute_test.go
+++ b/test/e2e/single_header_based_grpcroute_test.go
@@ -195,7 +195,7 @@ func testSingleHeaderBasedGRPCRoute(ctx context.Context, t *testing.T, config *e
 		wait.WithInterval(SHORT_PERIOD),
 	)
 	if err != nil {
-		logrus.Errorf("grpcRoute %q updation was failed: %s", resourcesMap[GRPC_ROUTE_KEY].GetName(), err)
+		logrus.Errorf("grpcRoute %q updating failed: %s", resourcesMap[GRPC_ROUTE_KEY].GetName(), err)
 		t.Error()
 		return ctx
 	}
@@ -268,14 +268,14 @@ func testSingleHeaderBasedGRPCRoute(ctx context.Context, t *testing.T, config *e
 			getMatchHeaderBasedGRPCRouteFetcher(
 				t,
 				FIRST_CANARY_ROUTE_WEIGHT,
-				FIRST_HEADER_BASED_GRPC_ROUTE_VALUE,
+				LAST_HEADER_BASED_GRPC_ROUTE_VALUE,
 			),
 		),
 		wait.WithTimeout(LONG_PERIOD),
 		wait.WithInterval(SHORT_PERIOD),
 	)
 	if err != nil {
-		logrus.Errorf("last grpcRoute %q updation was failed: %s", resourcesMap[GRPC_ROUTE_KEY].GetName(), err)
+		logrus.Errorf("last grpcRoute %q update failed: %s", resourcesMap[GRPC_ROUTE_KEY].GetName(), err)
 		t.Error()
 		return ctx
 	}
@@ -318,14 +318,12 @@ func getMatchHeaderBasedGRPCRouteFetcher(t *testing.T, targetWeight int32, targe
 			t.Error()
 			return false
 		}
-		// logrus.Info("k8s object was type asserted")
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredGRPCRoute.Object, &grpcRoute)
 		if err != nil {
 			logrus.Errorf("conversation from unstructured grpcRoute %q to the typed grpcRoute was failed", unstructuredGRPCRoute.GetName())
 			t.Error()
 			return false
 		}
-		// logrus.Infof("unstructured grpcRoute %q was converted to the typed grpcRoute", grpcRoute.GetName())
 		rules := grpcRoute.Spec.Rules
 		if targetHeaderBasedRouteValue.Type == nil {
 			return len(rules) == LAST_HEADER_BASED_RULES_LENGTH &&

--- a/test/e2e/single_header_based_httproute_test.go
+++ b/test/e2e/single_header_based_httproute_test.go
@@ -195,7 +195,7 @@ func testSingleHeaderBasedHTTPRoute(ctx context.Context, t *testing.T, config *e
 		wait.WithInterval(SHORT_PERIOD),
 	)
 	if err != nil {
-		logrus.Errorf("httpRoute %q updation was failed: %s", resourcesMap[HTTP_ROUTE_KEY].GetName(), err)
+		logrus.Errorf("httpRoute %q updating failed: %s", resourcesMap[HTTP_ROUTE_KEY].GetName(), err)
 		t.Error()
 		return ctx
 	}
@@ -268,14 +268,14 @@ func testSingleHeaderBasedHTTPRoute(ctx context.Context, t *testing.T, config *e
 			getMatchHeaderBasedHTTPRouteFetcher(
 				t,
 				FIRST_CANARY_ROUTE_WEIGHT,
-				FIRST_HEADER_BASED_HTTP_ROUTE_VALUE,
+				LAST_HEADER_BASED_HTTP_ROUTE_VALUE,
 			),
 		),
 		wait.WithTimeout(LONG_PERIOD),
 		wait.WithInterval(SHORT_PERIOD),
 	)
 	if err != nil {
-		logrus.Errorf("last httpRoute %q updation was failed: %s", resourcesMap[HTTP_ROUTE_KEY].GetName(), err)
+		logrus.Errorf("last httpRoute %q update failed: %s", resourcesMap[HTTP_ROUTE_KEY].GetName(), err)
 		t.Error()
 		return ctx
 	}

--- a/test/e2e/single_header_based_httproute_test.go
+++ b/test/e2e/single_header_based_httproute_test.go
@@ -1,3 +1,5 @@
+//go:build flaky
+
 package e2e
 
 import (

--- a/test/e2e/single_header_based_httproute_test.go
+++ b/test/e2e/single_header_based_httproute_test.go
@@ -41,36 +41,36 @@ func setupSingleHeaderBasedHTTPRouteEnv(ctx context.Context, t *testing.T, confi
 	clusterResources := config.Client().Resources()
 	resourcesMap := map[string]*unstructured.Unstructured{}
 	ctx = context.WithValue(ctx, RESOURCES_MAP_KEY, resourcesMap)
-	firstHTTPRouteFile, err := os.Open(FIRST_HTTP_ROUTE_PATH)
+	firstHTTPRouteFile, err := os.Open(HTTP_ROUTE_HEADER_PATH)
 	if err != nil {
-		logrus.Errorf("file %q openning was failed: %s", FIRST_HTTP_ROUTE_PATH, err)
+		logrus.Errorf("file %q openning was failed: %s", HTTP_ROUTE_HEADER_PATH, err)
 		t.Error()
 		return ctx
 	}
 	defer firstHTTPRouteFile.Close()
-	logrus.Infof("file %q was opened", FIRST_HTTP_ROUTE_PATH)
-	rolloutFile, err := os.Open(SINGLE_HEADER_BASED_HTTP_ROUTE_ROLLOUT_PATH)
+	logrus.Infof("file %q was opened", HTTP_ROUTE_HEADER_PATH)
+	rolloutFile, err := os.Open(HTTP_ROUTE_HEADER_ROLLOUT_PATH)
 	if err != nil {
-		logrus.Errorf("file %q openning was failed: %s", SINGLE_HEADER_BASED_HTTP_ROUTE_ROLLOUT_PATH, err)
+		logrus.Errorf("file %q openning was failed: %s", HTTP_ROUTE_HEADER_ROLLOUT_PATH, err)
 		t.Error()
 		return ctx
 	}
 	defer rolloutFile.Close()
-	logrus.Infof("file %q was opened", SINGLE_HEADER_BASED_HTTP_ROUTE_ROLLOUT_PATH)
+	logrus.Infof("file %q was opened", HTTP_ROUTE_HEADER_ROLLOUT_PATH)
 	err = decoder.Decode(firstHTTPRouteFile, &httpRoute)
 	if err != nil {
-		logrus.Errorf("file %q decoding was failed: %s", FIRST_HTTP_ROUTE_PATH, err)
+		logrus.Errorf("file %q decoding was failed: %s", HTTP_ROUTE_HEADER_PATH, err)
 		t.Error()
 		return ctx
 	}
-	logrus.Infof("file %q was decoded", FIRST_HTTP_ROUTE_PATH)
+	logrus.Infof("file %q was decoded", HTTP_ROUTE_HEADER_PATH)
 	err = decoder.Decode(rolloutFile, &rollout)
 	if err != nil {
-		logrus.Errorf("file %q decoding was failed: %s", SINGLE_HEADER_BASED_HTTP_ROUTE_ROLLOUT_PATH, err)
+		logrus.Errorf("file %q decoding was failed: %s", HTTP_ROUTE_HEADER_ROLLOUT_PATH, err)
 		t.Error()
 		return ctx
 	}
-	logrus.Infof("file %q was decoded", SINGLE_HEADER_BASED_HTTP_ROUTE_ROLLOUT_PATH)
+	logrus.Infof("file %q was decoded", HTTP_ROUTE_HEADER_ROLLOUT_PATH)
 	httpRouteObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&httpRoute)
 	if err != nil {
 		logrus.Errorf("httpRoute %q converting to unstructured was failed: %s", httpRoute.GetName(), err)

--- a/test/e2e/single_header_based_httproute_test.go
+++ b/test/e2e/single_header_based_httproute_test.go
@@ -107,6 +107,7 @@ func setupSingleHeaderBasedHTTPRouteEnv(ctx context.Context, t *testing.T, confi
 	}
 	logrus.Infof("rollout %q was created", resourcesMap[ROLLOUT_KEY].GetName())
 	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for httpRoute %q to connect with rollout %q (expecting canary weight: %d)", resourcesMap[HTTP_ROUTE_KEY].GetName(), resourcesMap[ROLLOUT_KEY].GetName(), FIRST_CANARY_ROUTE_WEIGHT)
 	err = wait.For(
 		waitCondition.ResourceMatch(
 			resourcesMap[HTTP_ROUTE_KEY],
@@ -180,6 +181,7 @@ func testSingleHeaderBasedHTTPRoute(ctx context.Context, t *testing.T, config *e
 	}
 	logrus.Infof("rollout %q was updated", resourcesMap[ROLLOUT_KEY].GetName())
 	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for httpRoute %q to update with header-based routing and canary weight %d", resourcesMap[HTTP_ROUTE_KEY].GetName(), LAST_CANARY_ROUTE_WEIGHT)
 	err = wait.For(
 		waitCondition.ResourceMatch(
 			resourcesMap[HTTP_ROUTE_KEY],
@@ -198,6 +200,7 @@ func testSingleHeaderBasedHTTPRoute(ctx context.Context, t *testing.T, config *e
 		return ctx
 	}
 	logrus.Infof("httpRoute %q was updated", resourcesMap[HTTP_ROUTE_KEY].GetName())
+	logrus.Infof("waiting for httpRoute %q to clean up header-based routing and reset canary weight to %d", resourcesMap[HTTP_ROUTE_KEY].GetName(), FIRST_CANARY_ROUTE_WEIGHT)
 	err = wait.For(
 		waitCondition.ResourceMatch(
 			resourcesMap[HTTP_ROUTE_KEY],
@@ -254,14 +257,14 @@ func getMatchHeaderBasedHTTPRouteFetcher(t *testing.T, targetWeight int32, targe
 			t.Error()
 			return false
 		}
-		logrus.Info("k8s object was type asserted")
+		// logrus.Info("k8s object was type asserted")
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredHTTPRoute.Object, &httpRoute)
 		if err != nil {
 			logrus.Errorf("conversation from unstructured httpRoute %q to the typed httpRoute was failed", unstructuredHTTPRoute.GetName())
 			t.Error()
 			return false
 		}
-		logrus.Infof("unstructured httpRoute %q was converted to the typed httpRoute", httpRoute.GetName())
+		// logrus.Infof("unstructured httpRoute %q was converted to the typed httpRoute", httpRoute.GetName())
 		rules := httpRoute.Spec.Rules
 		if targetHeaderBasedRouteValue.Type == nil {
 			return len(rules) == LAST_HEADER_BASED_RULES_LENGTH &&

--- a/test/e2e/single_header_based_httproute_test.go
+++ b/test/e2e/single_header_based_httproute_test.go
@@ -200,6 +200,67 @@ func testSingleHeaderBasedHTTPRoute(ctx context.Context, t *testing.T, config *e
 		return ctx
 	}
 	logrus.Infof("httpRoute %q was updated", resourcesMap[HTTP_ROUTE_KEY].GetName())
+	// Manually promote the canary by removing the pause step to allow rollout to finish
+	unstructured.RemoveNestedField(resourcesMap[ROLLOUT_KEY].Object, "metadata", "resourceVersion")
+	// Remove the pause step from the canary strategy steps
+	steps, found, err := unstructured.NestedSlice(resourcesMap[ROLLOUT_KEY].Object, "spec", "strategy", "canary", "steps")
+	if !found || err != nil {
+		logrus.Errorf("rollout %q canary steps not found or error: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	// Filter out the pause step from the steps array
+	var filteredSteps []interface{}
+	for _, step := range steps {
+		stepMap, ok := step.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		// Skip any step that contains a "pause" key
+		if _, hasPause := stepMap["pause"]; !hasPause {
+			filteredSteps = append(filteredSteps, step)
+		}
+	}
+	err = unstructured.SetNestedSlice(resourcesMap[ROLLOUT_KEY].Object, filteredSteps, "spec", "strategy", "canary", "steps")
+	if err != nil {
+		logrus.Errorf("rollout %q steps update failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	serializedRolloutPromotion, err := json.Marshal(resourcesMap[ROLLOUT_KEY].Object)
+	if err != nil {
+		logrus.Errorf("rollout %q promotion serializing was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q promotion was serialized", resourcesMap[ROLLOUT_KEY].GetName())
+	rolloutPromotionPatch := k8s.Patch{
+		PatchType: types.MergePatchType,
+		Data:      serializedRolloutPromotion,
+	}
+	err = clusterResources.Patch(ctx, resourcesMap[ROLLOUT_KEY], rolloutPromotionPatch)
+	if err != nil {
+		logrus.Errorf("rollout %q promotion was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was promoted to finish canary deployment", resourcesMap[ROLLOUT_KEY].GetName())
+	// Wait for rollout to reach a healthy finished state
+	logrus.Infof("waiting for rollout %q to complete and reach healthy status", resourcesMap[ROLLOUT_KEY].GetName())
+	err = wait.For(
+		waitCondition.ResourceMatch(
+			resourcesMap[ROLLOUT_KEY],
+			getRolloutHealthyFetcher(t),
+		),
+		wait.WithTimeout(LONG_PERIOD),
+		wait.WithInterval(SHORT_PERIOD),
+	)
+	if err != nil {
+		logrus.Errorf("rollout %q completion was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q completed successfully", resourcesMap[ROLLOUT_KEY].GetName())
 	logrus.Infof("waiting for httpRoute %q to clean up header-based routing and reset canary weight to %d", resourcesMap[HTTP_ROUTE_KEY].GetName(), FIRST_CANARY_ROUTE_WEIGHT)
 	err = wait.For(
 		waitCondition.ResourceMatch(

--- a/test/e2e/single_httproute_test.go
+++ b/test/e2e/single_httproute_test.go
@@ -43,36 +43,36 @@ func setupSingleHTTPRouteEnv(ctx context.Context, t *testing.T, config *envconf.
 	clusterResources := config.Client().Resources()
 	resourcesMap := map[string]*unstructured.Unstructured{}
 	ctx = context.WithValue(ctx, RESOURCES_MAP_KEY, resourcesMap)
-	firstHTTPRouteFile, err := os.Open(FIRST_HTTP_ROUTE_PATH)
+	firstHTTPRouteFile, err := os.Open(HTTP_ROUTE_BASIC_PATH)
 	if err != nil {
-		logrus.Errorf("file %q openning was failed: %s", FIRST_HTTP_ROUTE_PATH, err)
+		logrus.Errorf("file %q openning was failed: %s", HTTP_ROUTE_BASIC_PATH, err)
 		t.Error()
 		return ctx
 	}
 	defer firstHTTPRouteFile.Close()
-	logrus.Infof("file %q was opened", FIRST_HTTP_ROUTE_PATH)
-	rolloutFile, err := os.Open(SINGLE_HTTP_ROUTE_ROLLOUT_PATH)
+	logrus.Infof("file %q was opened", HTTP_ROUTE_BASIC_PATH)
+	rolloutFile, err := os.Open(HTTP_ROUTE_BASIC_ROLLOUT_PATH)
 	if err != nil {
-		logrus.Errorf("file %q openning was failed: %s", SINGLE_HTTP_ROUTE_ROLLOUT_PATH, err)
+		logrus.Errorf("file %q openning was failed: %s", HTTP_ROUTE_BASIC_ROLLOUT_PATH, err)
 		t.Error()
 		return ctx
 	}
 	defer rolloutFile.Close()
-	logrus.Infof("file %q was opened", SINGLE_HTTP_ROUTE_ROLLOUT_PATH)
+	logrus.Infof("file %q was opened", HTTP_ROUTE_BASIC_ROLLOUT_PATH)
 	err = decoder.Decode(firstHTTPRouteFile, &httpRoute)
 	if err != nil {
-		logrus.Errorf("file %q decoding was failed: %s", FIRST_HTTP_ROUTE_PATH, err)
+		logrus.Errorf("file %q decoding was failed: %s", HTTP_ROUTE_BASIC_PATH, err)
 		t.Error()
 		return ctx
 	}
-	logrus.Infof("file %q was decoded", FIRST_HTTP_ROUTE_PATH)
+	logrus.Infof("file %q was decoded", HTTP_ROUTE_BASIC_PATH)
 	err = decoder.Decode(rolloutFile, &rollout)
 	if err != nil {
-		logrus.Errorf("file %q decoding was failed: %s", SINGLE_HTTP_ROUTE_ROLLOUT_PATH, err)
+		logrus.Errorf("file %q decoding was failed: %s", HTTP_ROUTE_BASIC_ROLLOUT_PATH, err)
 		t.Error()
 		return ctx
 	}
-	logrus.Infof("file %q was decoded", SINGLE_HTTP_ROUTE_ROLLOUT_PATH)
+	logrus.Infof("file %q was decoded", HTTP_ROUTE_BASIC_ROLLOUT_PATH)
 	httpRouteObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&httpRoute)
 	if err != nil {
 		logrus.Errorf("httpRoute %q converting to unstructured was failed: %s", httpRoute.GetName(), err)

--- a/test/e2e/single_httproute_test.go
+++ b/test/e2e/single_httproute_test.go
@@ -109,6 +109,7 @@ func setupSingleHTTPRouteEnv(ctx context.Context, t *testing.T, config *envconf.
 	}
 	logrus.Infof("rollout %q was created", resourcesMap[ROLLOUT_KEY].GetName())
 	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for httpRoute %q to connect with rollout %q (expecting canary weight: %d)", resourcesMap[HTTP_ROUTE_KEY].GetName(), resourcesMap[ROLLOUT_KEY].GetName(), FIRST_CANARY_ROUTE_WEIGHT)
 	err = wait.For(
 		waitCondition.ResourceMatch(
 			resourcesMap[HTTP_ROUTE_KEY],
@@ -182,6 +183,7 @@ func testSingleHTTPRoute(ctx context.Context, t *testing.T, config *envconf.Conf
 	}
 	logrus.Infof("rollout %q was updated", resourcesMap[ROLLOUT_KEY].GetName())
 	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for httpRoute %q to update canary weight to %d after rollout image change", resourcesMap[HTTP_ROUTE_KEY].GetName(), LAST_CANARY_ROUTE_WEIGHT)
 	err = wait.For(
 		waitCondition.ResourceMatch(
 			resourcesMap[HTTP_ROUTE_KEY],
@@ -234,14 +236,14 @@ func getMatchHTTPRouteFetcher(t *testing.T, targetWeight int32) func(k8s.Object)
 			t.Error()
 			return false
 		}
-		logrus.Info("k8s object was type asserted")
+		// logrus.Info("k8s object was type asserted")
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredHTTPRoute.Object, &httpRoute)
 		if err != nil {
 			logrus.Errorf("conversation from unstructured httpRoute %q to the typed httpRoute was failed", unstructuredHTTPRoute.GetName())
 			t.Error()
 			return false
 		}
-		logrus.Infof("unstructured httpRoute %q was converted to the typed httpRoute", httpRoute.GetName())
+		// logrus.Infof("unstructured httpRoute %q was converted to the typed httpRoute", httpRoute.GetName())
 		return *httpRoute.Spec.Rules[ROLLOUT_ROUTE_RULE_INDEX].BackendRefs[CANARY_BACKEND_REF_INDEX].Weight == targetWeight
 	}
 }

--- a/test/e2e/single_httproute_test.go
+++ b/test/e2e/single_httproute_test.go
@@ -193,7 +193,7 @@ func testSingleHTTPRoute(ctx context.Context, t *testing.T, config *envconf.Conf
 		wait.WithInterval(SHORT_PERIOD),
 	)
 	if err != nil {
-		logrus.Errorf("httpRoute %q updation was failed: %s", resourcesMap[HTTP_ROUTE_KEY].GetName(), err)
+		logrus.Errorf("httpRoute %q updating failed: %s", resourcesMap[HTTP_ROUTE_KEY].GetName(), err)
 		t.Error()
 		return ctx
 	}

--- a/test/e2e/single_httproute_test.go
+++ b/test/e2e/single_httproute_test.go
@@ -1,3 +1,5 @@
+//go:build !flaky
+
 package e2e
 
 import (
@@ -225,25 +227,4 @@ func teardownSingleHTTPRouteEnv(ctx context.Context, t *testing.T, config *envco
 	}
 	logrus.Infof("httpRoute %q was deleted", resourcesMap[HTTP_ROUTE_KEY].GetName())
 	return ctx
-}
-
-func getMatchHTTPRouteFetcher(t *testing.T, targetWeight int32) func(k8s.Object) bool {
-	return func(obj k8s.Object) bool {
-		var httpRoute gatewayv1.HTTPRoute
-		unstructuredHTTPRoute, ok := obj.(*unstructured.Unstructured)
-		if !ok {
-			logrus.Error("k8s object type assertion was failed")
-			t.Error()
-			return false
-		}
-		// logrus.Info("k8s object was type asserted")
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredHTTPRoute.Object, &httpRoute)
-		if err != nil {
-			logrus.Errorf("conversation from unstructured httpRoute %q to the typed httpRoute was failed", unstructuredHTTPRoute.GetName())
-			t.Error()
-			return false
-		}
-		// logrus.Infof("unstructured httpRoute %q was converted to the typed httpRoute", httpRoute.GetName())
-		return *httpRoute.Spec.Rules[ROLLOUT_ROUTE_RULE_INDEX].BackendRefs[CANARY_BACKEND_REF_INDEX].Weight == targetWeight
-	}
 }

--- a/test/e2e/single_tcproute_test.go
+++ b/test/e2e/single_tcproute_test.go
@@ -107,6 +107,7 @@ func setupSingleTCPRouteEnv(ctx context.Context, t *testing.T, config *envconf.C
 	}
 	logrus.Infof("rollout %q was created", resourcesMap[ROLLOUT_KEY].GetName())
 	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for tcpRoute %q to connect with rollout %q (expecting canary weight: %d)", resourcesMap[TCP_ROUTE_KEY].GetName(), resourcesMap[ROLLOUT_KEY].GetName(), FIRST_CANARY_ROUTE_WEIGHT)
 	err = wait.For(
 		waitCondition.ResourceMatch(
 			resourcesMap[TCP_ROUTE_KEY],
@@ -180,6 +181,7 @@ func testSingleTCPRoute(ctx context.Context, t *testing.T, config *envconf.Confi
 	}
 	logrus.Infof("rollout %q was updated", resourcesMap[ROLLOUT_KEY].GetName())
 	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for tcpRoute %q to update canary weight to %d after rollout image change", resourcesMap[TCP_ROUTE_KEY].GetName(), LAST_CANARY_ROUTE_WEIGHT)
 	err = wait.For(
 		waitCondition.ResourceMatch(
 			resourcesMap[TCP_ROUTE_KEY],
@@ -232,14 +234,14 @@ func getMatchTCPRouteFetcher(t *testing.T, targetWeight int32) func(k8s.Object) 
 			t.Error()
 			return false
 		}
-		logrus.Info("k8s object was type asserted")
+		// logrus.Info("k8s object was type asserted")
 		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredTCPRoute.Object, &tcpRoute)
 		if err != nil {
 			logrus.Errorf("conversation from unstructured tcpRoute %q to the typed tcpRoute was failed", unstructuredTCPRoute.GetName())
 			t.Error()
 			return false
 		}
-		logrus.Infof("unstructured tcpRoute %q was converted to the typed tcpRoute", tcpRoute.GetName())
+		// logrus.Infof("unstructured tcpRoute %q was converted to the typed tcpRoute", tcpRoute.GetName())
 		return *tcpRoute.Spec.Rules[ROLLOUT_ROUTE_RULE_INDEX].BackendRefs[CANARY_BACKEND_REF_INDEX].Weight == targetWeight
 	}
 }

--- a/test/e2e/single_tcproute_test.go
+++ b/test/e2e/single_tcproute_test.go
@@ -191,7 +191,7 @@ func testSingleTCPRoute(ctx context.Context, t *testing.T, config *envconf.Confi
 		wait.WithInterval(SHORT_PERIOD),
 	)
 	if err != nil {
-		logrus.Errorf("tcpRoute %q updation was failed: %s", resourcesMap[TCP_ROUTE_KEY].GetName(), err)
+		logrus.Errorf("tcpRoute %q updating failed: %s", resourcesMap[TCP_ROUTE_KEY].GetName(), err)
 		t.Error()
 		return ctx
 	}

--- a/test/e2e/single_tcproute_test.go
+++ b/test/e2e/single_tcproute_test.go
@@ -41,36 +41,36 @@ func setupSingleTCPRouteEnv(ctx context.Context, t *testing.T, config *envconf.C
 	clusterResources := config.Client().Resources()
 	resourcesMap := map[string]*unstructured.Unstructured{}
 	ctx = context.WithValue(ctx, RESOURCES_MAP_KEY, resourcesMap)
-	firstTCPRouteFile, err := os.Open(FIRST_TCP_ROUTE_PATH)
+	firstTCPRouteFile, err := os.Open(TCP_ROUTE_BASIC_PATH)
 	if err != nil {
-		logrus.Errorf("file %q openning was failed: %s", FIRST_TCP_ROUTE_PATH, err)
+		logrus.Errorf("file %q openning was failed: %s", TCP_ROUTE_BASIC_PATH, err)
 		t.Error()
 		return ctx
 	}
 	defer firstTCPRouteFile.Close()
-	logrus.Infof("file %q was opened", FIRST_TCP_ROUTE_PATH)
-	rolloutFile, err := os.Open(SINGLE_TCP_ROUTE_ROLLOUT_PATH)
+	logrus.Infof("file %q was opened", TCP_ROUTE_BASIC_PATH)
+	rolloutFile, err := os.Open(TCP_ROUTE_BASIC_ROLLOUT_PATH)
 	if err != nil {
-		logrus.Errorf("file %q openning was failed: %s", SINGLE_TCP_ROUTE_ROLLOUT_PATH, err)
+		logrus.Errorf("file %q openning was failed: %s", TCP_ROUTE_BASIC_ROLLOUT_PATH, err)
 		t.Error()
 		return ctx
 	}
 	defer rolloutFile.Close()
-	logrus.Infof("file %q was opened", SINGLE_TCP_ROUTE_ROLLOUT_PATH)
+	logrus.Infof("file %q was opened", TCP_ROUTE_BASIC_ROLLOUT_PATH)
 	err = decoder.Decode(firstTCPRouteFile, &tcpRoute)
 	if err != nil {
-		logrus.Errorf("file %q decoding was failed: %s", FIRST_TCP_ROUTE_PATH, err)
+		logrus.Errorf("file %q decoding was failed: %s", TCP_ROUTE_BASIC_PATH, err)
 		t.Error()
 		return ctx
 	}
-	logrus.Infof("file %q was decoded", FIRST_TCP_ROUTE_PATH)
+	logrus.Infof("file %q was decoded", TCP_ROUTE_BASIC_PATH)
 	err = decoder.Decode(rolloutFile, &rollout)
 	if err != nil {
-		logrus.Errorf("file %q decoding was failed: %s", SINGLE_TCP_ROUTE_ROLLOUT_PATH, err)
+		logrus.Errorf("file %q decoding was failed: %s", TCP_ROUTE_BASIC_ROLLOUT_PATH, err)
 		t.Error()
 		return ctx
 	}
-	logrus.Infof("file %q was decoded", SINGLE_TCP_ROUTE_ROLLOUT_PATH)
+	logrus.Infof("file %q was decoded", TCP_ROUTE_BASIC_ROLLOUT_PATH)
 	tcpRouteObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tcpRoute)
 	if err != nil {
 		logrus.Errorf("tcpRoute %q converting to unstructured was failed: %s", tcpRoute.GetName(), err)

--- a/test/e2e/single_tcproute_test.go
+++ b/test/e2e/single_tcproute_test.go
@@ -1,3 +1,5 @@
+//go:build !flaky
+
 package e2e
 
 import (

--- a/test/e2e/testdata/grpcroute-basic.yml
+++ b/test/e2e/testdata/grpcroute-basic.yml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: grpcroute-basic
+  namespace: default
+spec:
+  parentRefs:
+    - name: traefik-gateway
+  rules:
+    - backendRefs:
+        - name: argo-rollouts-stable-service
+          port: 80
+        - name: argo-rollouts-canary-service
+          port: 80

--- a/test/e2e/testdata/grpcroute-header.yml
+++ b/test/e2e/testdata/grpcroute-header.yml
@@ -1,14 +1,11 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
-kind: TCPRoute
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
 metadata:
-  name: first-tcproute
+  name: grpcroute-header
   namespace: default
 spec:
   parentRefs:
     - name: traefik-gateway
-      sectionName: tcp
-      namespace: default
-      kind: Gateway
   rules:
     - backendRefs:
         - name: argo-rollouts-stable-service

--- a/test/e2e/testdata/httproute-basic.yml
+++ b/test/e2e/testdata/httproute-basic.yml
@@ -1,11 +1,12 @@
 apiVersion: gateway.networking.k8s.io/v1
-kind: GRPCRoute
+kind: HTTPRoute
 metadata:
-  name: first-grpcroute
+  name: httproute-basic
   namespace: default
 spec:
   parentRefs:
     - name: traefik-gateway
+      namespace: default
   rules:
     - backendRefs:
         - name: argo-rollouts-stable-service

--- a/test/e2e/testdata/httproute-header.yml
+++ b/test/e2e/testdata/httproute-header.yml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: first-httproute
+  name: httproute-header
   namespace: default
 spec:
   parentRefs:

--- a/test/e2e/testdata/single-grpcroute-rollout.yml
+++ b/test/e2e/testdata/single-grpcroute-rollout.yml
@@ -16,7 +16,7 @@ spec:
             namespace: default
       steps:
         - setWeight: 30
-        - pause: { duration: 2 }
+        - pause: {}
   revisionHistoryLimit: 1
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-grpcroute-rollout.yml
+++ b/test/e2e/testdata/single-grpcroute-rollout.yml
@@ -16,7 +16,7 @@ spec:
             namespace: default
       steps:
         - setWeight: 30
-        - pause: { 30 }
+        - pause: {  }
   revisionHistoryLimit: 1
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-grpcroute-rollout.yml
+++ b/test/e2e/testdata/single-grpcroute-rollout.yml
@@ -16,7 +16,7 @@ spec:
             namespace: default
       steps:
         - setWeight: 30
-        - pause: { 60 }
+        - pause: { 30 }
   revisionHistoryLimit: 1
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-grpcroute-rollout.yml
+++ b/test/e2e/testdata/single-grpcroute-rollout.yml
@@ -16,7 +16,7 @@ spec:
             namespace: default
       steps:
         - setWeight: 30
-        - pause: {}
+        - pause: { 60 }
   revisionHistoryLimit: 1
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-grpcroute-rollout.yml
+++ b/test/e2e/testdata/single-grpcroute-rollout.yml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
-  name: rollouts-demo
+  name: grpcroute-rollout
   namespace: default
 spec:
   replicas: 2
@@ -12,7 +12,7 @@ spec:
       trafficRouting:
         plugins:
           argoproj-labs/gatewayAPI:
-            grpcRoute: first-grpcroute
+            grpcRoute: grpcroute-basic
             namespace: default
       steps:
         - setWeight: 30

--- a/test/e2e/testdata/single-header-based-grpcroute-rollout.yml
+++ b/test/e2e/testdata/single-header-based-grpcroute-rollout.yml
@@ -26,7 +26,7 @@ spec:
             - headerName: X-Test
               headerValue:
                 exact: test  
-      - pause: {}
+      - pause: { 60 }
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-header-based-grpcroute-rollout.yml
+++ b/test/e2e/testdata/single-header-based-grpcroute-rollout.yml
@@ -26,7 +26,7 @@ spec:
             - headerName: X-Test
               headerValue:
                 exact: test  
-      - pause: { 30 }
+      - pause: {  }
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-header-based-grpcroute-rollout.yml
+++ b/test/e2e/testdata/single-header-based-grpcroute-rollout.yml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
-  name: rollouts-demo
+  name: grpcroute-header-rollout
   namespace: default
 spec:
   replicas: 2
@@ -15,7 +15,7 @@ spec:
         plugins:
           argoproj-labs/gatewayAPI:
             grpcRoutes:
-              - name: first-grpcroute
+              - name: grpcroute-header
                 useHeaderRoutes: true
             namespace: default
       steps:

--- a/test/e2e/testdata/single-header-based-grpcroute-rollout.yml
+++ b/test/e2e/testdata/single-header-based-grpcroute-rollout.yml
@@ -26,7 +26,7 @@ spec:
             - headerName: X-Test
               headerValue:
                 exact: test  
-      - pause: { 60 }
+      - pause: { 30 }
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-header-based-grpcroute-rollout.yml
+++ b/test/e2e/testdata/single-header-based-grpcroute-rollout.yml
@@ -26,7 +26,7 @@ spec:
             - headerName: X-Test
               headerValue:
                 exact: test  
-      - pause: { duration: 2 }
+      - pause: {}
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-header-based-httproute-rollout.yml
+++ b/test/e2e/testdata/single-header-based-httproute-rollout.yml
@@ -26,7 +26,7 @@ spec:
             - headerName: X-Test
               headerValue:
                 exact: test  
-      - pause: {}
+      - pause: { 60 }
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-header-based-httproute-rollout.yml
+++ b/test/e2e/testdata/single-header-based-httproute-rollout.yml
@@ -26,7 +26,7 @@ spec:
             - headerName: X-Test
               headerValue:
                 exact: test  
-      - pause: { 30 }
+      - pause: {  }
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-header-based-httproute-rollout.yml
+++ b/test/e2e/testdata/single-header-based-httproute-rollout.yml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
-  name: rollouts-demo
+  name: httproute-header-rollout
   namespace: default
 spec:
   replicas: 2
@@ -15,7 +15,7 @@ spec:
         plugins:
           argoproj-labs/gatewayAPI:
             httpRoutes:
-              - name: first-httproute
+              - name: httproute-header
                 useHeaderRoutes: true
             namespace: default
       steps:

--- a/test/e2e/testdata/single-header-based-httproute-rollout.yml
+++ b/test/e2e/testdata/single-header-based-httproute-rollout.yml
@@ -26,7 +26,7 @@ spec:
             - headerName: X-Test
               headerValue:
                 exact: test  
-      - pause: { 60 }
+      - pause: { 30 }
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-header-based-httproute-rollout.yml
+++ b/test/e2e/testdata/single-header-based-httproute-rollout.yml
@@ -26,7 +26,7 @@ spec:
             - headerName: X-Test
               headerValue:
                 exact: test  
-      - pause: { duration: 2 }
+      - pause: {}
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-httproute-rollout.yml
+++ b/test/e2e/testdata/single-httproute-rollout.yml
@@ -16,7 +16,7 @@ spec:
             namespace: default
       steps:
         - setWeight: 30
-        - pause: { duration: 2 }
+        - pause: {}
   revisionHistoryLimit: 1
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-httproute-rollout.yml
+++ b/test/e2e/testdata/single-httproute-rollout.yml
@@ -16,7 +16,7 @@ spec:
             namespace: default
       steps:
         - setWeight: 30
-        - pause: { 30 }
+        - pause: {  }
   revisionHistoryLimit: 1
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-httproute-rollout.yml
+++ b/test/e2e/testdata/single-httproute-rollout.yml
@@ -16,7 +16,7 @@ spec:
             namespace: default
       steps:
         - setWeight: 30
-        - pause: { 60 }
+        - pause: { 30 }
   revisionHistoryLimit: 1
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-httproute-rollout.yml
+++ b/test/e2e/testdata/single-httproute-rollout.yml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
-  name: rollouts-demo
+  name: httproute-rollout
   namespace: default
 spec:
   replicas: 2
@@ -12,7 +12,7 @@ spec:
       trafficRouting:
         plugins:
           argoproj-labs/gatewayAPI:
-            httpRoute: first-httproute
+            httpRoute: httproute-basic
             namespace: default
       steps:
         - setWeight: 30

--- a/test/e2e/testdata/single-httproute-rollout.yml
+++ b/test/e2e/testdata/single-httproute-rollout.yml
@@ -16,7 +16,7 @@ spec:
             namespace: default
       steps:
         - setWeight: 30
-        - pause: {}
+        - pause: { 60 }
   revisionHistoryLimit: 1
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-tcproute-rollout.yml
+++ b/test/e2e/testdata/single-tcproute-rollout.yml
@@ -16,7 +16,7 @@ spec:
             namespace: default
       steps:
         - setWeight: 30
-        - pause: { duration: 2 }
+        - pause: {}
   revisionHistoryLimit: 1
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-tcproute-rollout.yml
+++ b/test/e2e/testdata/single-tcproute-rollout.yml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
-  name: rollouts-demo
+  name: tcproute-rollout
   namespace: default
 spec:
   replicas: 2
@@ -12,7 +12,7 @@ spec:
       trafficRouting:
         plugins:
           argoproj-labs/gatewayAPI:
-            tcpRoute: first-tcproute
+            tcpRoute: tcproute-basic
             namespace: default
       steps:
         - setWeight: 30

--- a/test/e2e/testdata/single-tcproute-rollout.yml
+++ b/test/e2e/testdata/single-tcproute-rollout.yml
@@ -16,7 +16,7 @@ spec:
             namespace: default
       steps:
         - setWeight: 30
-        - pause: { 60 }
+        - pause: { 30 }
   revisionHistoryLimit: 1
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-tcproute-rollout.yml
+++ b/test/e2e/testdata/single-tcproute-rollout.yml
@@ -16,7 +16,7 @@ spec:
             namespace: default
       steps:
         - setWeight: 30
-        - pause: { 30 }
+        - pause: { }
   revisionHistoryLimit: 1
   selector:
     matchLabels:

--- a/test/e2e/testdata/single-tcproute-rollout.yml
+++ b/test/e2e/testdata/single-tcproute-rollout.yml
@@ -16,7 +16,7 @@ spec:
             namespace: default
       steps:
         - setWeight: 30
-        - pause: {}
+        - pause: { 60 }
   revisionHistoryLimit: 1
   selector:
     matchLabels:

--- a/test/e2e/testdata/tcproute-basic.yml
+++ b/test/e2e/testdata/tcproute-basic.yml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: tcproute-basic
+  namespace: default
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      sectionName: tcp
+      namespace: default
+      kind: Gateway
+  rules:
+    - backendRefs:
+        - name: argo-rollouts-stable-service
+          port: 80
+        - name: argo-rollouts-canary-service
+          port: 80

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -3,34 +3,12 @@ package e2e
 import (
 	"testing"
 
-	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
-
-func getRolloutHealthyFetcher(t *testing.T) func(k8s.Object) bool {
-	return func(obj k8s.Object) bool {
-		var rollout v1alpha1.Rollout
-		unstructuredRollout, ok := obj.(*unstructured.Unstructured)
-		if !ok {
-			logrus.Error("k8s rollout object type assertion was failed")
-			t.Error()
-			return false
-		}
-		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredRollout.Object, &rollout)
-		if err != nil {
-			logrus.Errorf("conversation from unstructured rollout %q to the typed rollout was failed", unstructuredRollout.GetName())
-			t.Error()
-			return false
-		}
-		// Check if rollout is healthy (completed successfully)
-		// A rollout is considered finished when its phase is "Healthy"
-		return rollout.Status.Phase == "Healthy"
-	}
-}
 
 func getMatchHTTPRouteFetcher(t *testing.T, targetWeight int32) func(k8s.Object) bool {
 	return func(obj k8s.Object) bool {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -1,0 +1,75 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func getRolloutHealthyFetcher(t *testing.T) func(k8s.Object) bool {
+	return func(obj k8s.Object) bool {
+		var rollout v1alpha1.Rollout
+		unstructuredRollout, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			logrus.Error("k8s rollout object type assertion was failed")
+			t.Error()
+			return false
+		}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredRollout.Object, &rollout)
+		if err != nil {
+			logrus.Errorf("conversation from unstructured rollout %q to the typed rollout was failed", unstructuredRollout.GetName())
+			t.Error()
+			return false
+		}
+		// Check if rollout is healthy (completed successfully)
+		// A rollout is considered finished when its phase is "Healthy"
+		return rollout.Status.Phase == "Healthy"
+	}
+}
+
+func getMatchHTTPRouteFetcher(t *testing.T, targetWeight int32) func(k8s.Object) bool {
+	return func(obj k8s.Object) bool {
+		var httpRoute gatewayv1.HTTPRoute
+		unstructuredHTTPRoute, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			logrus.Error("k8s object type assertion was failed")
+			t.Error()
+			return false
+		}
+		// logrus.Info("k8s object was type asserted")
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredHTTPRoute.Object, &httpRoute)
+		if err != nil {
+			logrus.Errorf("conversation from unstructured httpRoute %q to the typed httpRoute was failed", unstructuredHTTPRoute.GetName())
+			t.Error()
+			return false
+		}
+		// logrus.Infof("unstructured httpRoute %q was converted to the typed httpRoute", httpRoute.GetName())
+		return *httpRoute.Spec.Rules[ROLLOUT_ROUTE_RULE_INDEX].BackendRefs[CANARY_BACKEND_REF_INDEX].Weight == targetWeight
+	}
+}
+
+func getMatchGRPCRouteFetcher(t *testing.T, targetWeight int32) func(k8s.Object) bool {
+	return func(obj k8s.Object) bool {
+		var grpcRoute gatewayv1.GRPCRoute
+		unstructuredGRPCRoute, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			logrus.Error("k8s object type assertion was failed")
+			t.Error()
+			return false
+		}
+		// logrus.Info("k8s object was type asserted")
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredGRPCRoute.Object, &grpcRoute)
+		if err != nil {
+			logrus.Errorf("conversation from unstructured grpcRoute %q to the typed grpcRoute was failed", unstructuredGRPCRoute.GetName())
+			t.Error()
+			return false
+		}
+		// logrus.Infof("Looking for grpcRoute %q to reach weight %d", grpcRoute.GetName(), targetWeight)
+		return *grpcRoute.Spec.Rules[ROLLOUT_ROUTE_RULE_INDEX].BackendRefs[CANARY_BACKEND_REF_INDEX].Weight == targetWeight
+	}
+}


### PR DESCRIPTION
Some initial work towards https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/issues/142

* Rollouts now wait for ever and tests don't assume when they are finished
* Logging completely changed to explain what a test does
* Each e2e test is creating and cleaning its own resource (running in isolation)
* Flaky tests were spit in their own test suite