### PR TITLE
feat: add support of TLSRoute

### DIFF
--- a/docs/features/tls.md
+++ b/docs/features/tls.md
@@ -1,0 +1,77 @@
+# TLS Routes
+
+To use TLSRoute:
+
+1. Install your traffic provider
+2. Install [GatewayAPI CRD](https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api) if your traffic provider doesn't do it by default
+3. Install [Argo Rollouts](https://argoproj.github.io/argo-rollouts/installation/)
+4. Install [Argo Rollouts GatewayAPI plugin](../installation.md)
+5. Create stable and canary services
+6. Create TLSRoute resource according to the GatewayAPI and your traffic provider documentation
+```yaml
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: first-tlsroute
+  namespace: default
+spec:
+  parentRefs:
+    - name: traefik-gateway # read documentation of your traffic provider to understand what you need to specify here
+      sectionName: tls
+      namespace: default
+      kind: Gateway
+  hostnames:
+    - "example.com" # SNI hostname for TLS traffic routing
+  rules:
+    - backendRefs:
+        - name: argo-rollouts-stable-service # stable service you have created on the 5th step
+          port: 443
+        - name: argo-rollouts-canary-service # canary service you have created on the 5th step
+          port: 443
+```
+7. Create Rollout resource
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollouts-demo
+  namespace: default
+spec:
+  replicas: 2
+  strategy:
+    canary:
+      canaryService: argo-rollouts-canary-service
+      stableService: argo-rollouts-stable-service
+      trafficRouting:
+        plugins:
+          argoproj-labs/gatewayAPI:
+            tlsRoute: first-tlsroute # tlsroute you have created on the 6th step
+            namespace: default # namespace where your tlsroute is
+      steps:
+        - setWeight: 30
+        - pause: { duration: 2 }
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: rollouts-demo
+  template:
+    metadata:
+      labels:
+        app: rollouts-demo
+    spec:
+      containers:
+        - name: rollouts-demo
+          image: argoproj/rollouts-demo:red
+          ports:
+            - name: https
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              memory: 32Mi
+              cpu: 5m
+```
+
+## Traffic Provider Support
+
+TLSRoute is part of the Gateway API experimental channel. Ensure your traffic provider supports TLSRoute before using it in production. Check the [Gateway API implementations list](https://gateway-api.sigs.k8s.io/implementations/) for TLSRoute support.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
   - Multiple Routes: features/multiple-routes.md
   - Header Based Routing: features/header-based-routing.md    
   - TCP Routing: features/tcp.md
+  - TLS Routing: features/tls.md
   - GRPC Routing: features/grpc.md  
 
 - Contributing: CONTRIBUTING.md

--- a/pkg/mocks/plugin.go
+++ b/pkg/mocks/plugin.go
@@ -12,11 +12,13 @@ import (
 const (
 	HTTPRoute         = "HTTPRoute"
 	TCPRoute          = "TCPRoute"
+	TLSRoute          = "TLSRoute"
 	StableServiceName = "argo-rollouts-stable-service"
 	CanaryServiceName = "argo-rollouts-canary-service"
 	HTTPRouteName     = "argo-rollouts-http-route"
 	GRPCRouteName     = "argo-rollouts-grpc-route"
 	TCPRouteName      = "argo-rollouts-tcp-route"
+	TLSRouteName      = "argo-rollouts-tls-route"
 	RolloutNamespace  = "default"
 	ConfigMapName     = "test-config"
 	ManagedRouteName  = "test-header-route"
@@ -186,6 +188,40 @@ func CreateTCPRouteWithLabels(name string, labels map[string]string) *v1alpha2.T
 	}
 }
 
+func CreateTLSRouteWithLabels(name string, labels map[string]string) *v1alpha2.TLSRoute {
+	stableWeight := int32(100)
+	canaryWeight := int32(0)
+	return &v1alpha2.TLSRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: RolloutNamespace,
+			Labels:    labels,
+		},
+		Spec: v1alpha2.TLSRouteSpec{
+			Rules: []v1alpha2.TLSRouteRule{
+				{
+					BackendRefs: []v1alpha2.BackendRef{
+						{
+							BackendObjectReference: v1alpha2.BackendObjectReference{
+								Name: StableServiceName,
+								Port: &port,
+							},
+							Weight: &stableWeight,
+						},
+						{
+							BackendObjectReference: v1alpha2.BackendObjectReference{
+								Name: CanaryServiceName,
+								Port: &port,
+							},
+							Weight: &canaryWeight,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 var GRPCRouteObj = gatewayv1.GRPCRoute{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      GRPCRouteName,
@@ -226,6 +262,35 @@ var TCPPRouteObj = v1alpha2.TCPRoute{
 	},
 	Spec: v1alpha2.TCPRouteSpec{
 		Rules: []v1alpha2.TCPRouteRule{
+			{
+				BackendRefs: []v1alpha2.BackendRef{
+					{
+						BackendObjectReference: v1alpha2.BackendObjectReference{
+							Name: StableServiceName,
+							Port: &port,
+						},
+						Weight: &weight,
+					},
+					{
+						BackendObjectReference: v1alpha2.BackendObjectReference{
+							Name: CanaryServiceName,
+							Port: &port,
+						},
+						Weight: &weight,
+					},
+				},
+			},
+		},
+	},
+}
+
+var TLSRouteObj = v1alpha2.TLSRoute{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      TLSRouteName,
+		Namespace: RolloutNamespace,
+	},
+	Spec: v1alpha2.TLSRouteSpec{
+		Rules: []v1alpha2.TLSRouteRule{
 			{
 				BackendRefs: []v1alpha2.BackendRef{
 					{

--- a/pkg/plugin/errors.go
+++ b/pkg/plugin/errors.go
@@ -2,12 +2,14 @@ package plugin
 
 const (
 	GatewayAPIUpdateError                    = "error updating Gateway API %q: %s"
-	GatewayAPIManifestError                  = "No routes configured. At least one of 'httpRoutes', 'grpcRoutes', 'tcpRoutes', 'httpRoute', 'grpcRoute' or 'tcpRoute' must be set"
+	GatewayAPIManifestError                  = "No routes configured. At least one of 'httpRoutes', 'grpcRoutes', 'tcpRoutes', 'tlsRoutes', 'httpRoute', 'grpcRoute', 'tcpRoute' or 'tlsRoute' must be set"
 	HTTPRouteFieldIsEmptyError               = "httpRoute field is empty. It has to be set to remove managed routes"
 	InvalidHeaderMatchTypeError              = "invalid header match type"
 	BackendRefWasNotFoundInHTTPRouteError    = "backendRef was not found in httpRoute"
 	BackendRefWasNotFoundInGRPCRouteError    = "backendRef was not found in grpcRoute"
 	BackendRefWasNotFoundInTCPRouteError     = "backendRef was not found in tcpRoute"
+	BackendRefWasNotFoundInTLSRouteError     = "backendRef was not found in tlsRoute"
 	BackendRefListWasNotFoundInTCPRouteError = "backendRef list was not found in tcpRoute"
+	BackendRefListWasNotFoundInTLSRouteError = "backendRef list was not found in tlsRoute"
 	ManagedRouteMapEntryDeleteError          = "can't delete key %q from managedRouteMap. The key %q is not in the managedRouteMap"
 )

--- a/pkg/plugin/tlsroute.go
+++ b/pkg/plugin/tlsroute.go
@@ -1,0 +1,97 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	pluginTypes "github.com/argoproj/argo-rollouts/utils/plugin/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *RpcPlugin) setTLSRouteWeight(rollout *v1alpha1.Rollout, desiredWeight int32, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
+	ctx := context.TODO()
+	tlsRouteClient := r.TLSRouteClient
+	if !r.IsTest {
+		gatewayClientV1alpha2 := r.GatewayAPIClientset.GatewayV1alpha2()
+		tlsRouteClient = gatewayClientV1alpha2.TLSRoutes(gatewayAPIConfig.Namespace)
+	}
+	tlsRoute, err := tlsRouteClient.Get(ctx, gatewayAPIConfig.TLSRoute, metav1.GetOptions{})
+	if err != nil {
+		return pluginTypes.RpcError{
+			ErrorString: err.Error(),
+		}
+	}
+	canaryServiceName := rollout.Spec.Strategy.Canary.CanaryService
+	stableServiceName := rollout.Spec.Strategy.Canary.StableService
+	routeRuleList := TLSRouteRuleList(tlsRoute.Spec.Rules)
+	canaryBackendRefs, err := getBackendRefs(canaryServiceName, routeRuleList)
+	if err != nil {
+		return pluginTypes.RpcError{
+			ErrorString: err.Error(),
+		}
+	}
+	for _, ref := range canaryBackendRefs {
+		ref.Weight = &desiredWeight
+	}
+	stableBackendRefs, err := getBackendRefs(stableServiceName, routeRuleList)
+	if err != nil {
+		return pluginTypes.RpcError{
+			ErrorString: err.Error(),
+		}
+	}
+	restWeight := 100 - desiredWeight
+	for _, ref := range stableBackendRefs {
+		ref.Weight = &restWeight
+	}
+	updatedTLSRoute, err := tlsRouteClient.Update(ctx, tlsRoute, metav1.UpdateOptions{})
+	if r.IsTest {
+		r.UpdatedTLSRouteMock = updatedTLSRoute
+	}
+	if err != nil {
+		return pluginTypes.RpcError{
+			ErrorString: err.Error(),
+		}
+	}
+	return pluginTypes.RpcError{}
+}
+
+func (r *TLSRouteRule) Iterator() (GatewayAPIRouteRuleIterator[*TLSBackendRef], bool) {
+	backendRefList := r.BackendRefs
+	index := 0
+	next := func() (*TLSBackendRef, bool) {
+		if len(backendRefList) == index {
+			return nil, false
+		}
+		backendRef := (*TLSBackendRef)(&backendRefList[index])
+		index = index + 1
+		return backendRef, len(backendRefList) > index
+	}
+	return next, len(backendRefList) > index
+}
+
+func (r TLSRouteRuleList) Iterator() (GatewayAPIRouteRuleListIterator[*TLSBackendRef, *TLSRouteRule], bool) {
+	routeRuleList := r
+	index := 0
+	next := func() (*TLSRouteRule, bool) {
+		if len(routeRuleList) == index {
+			return nil, false
+		}
+		routeRule := (*TLSRouteRule)(&routeRuleList[index])
+		index = index + 1
+		return routeRule, len(routeRuleList) > index
+	}
+	return next, len(routeRuleList) > index
+}
+
+func (r TLSRouteRuleList) Error() error {
+	return errors.New(BackendRefListWasNotFoundInTLSRouteError)
+}
+
+func (r *TLSBackendRef) GetName() string {
+	return string(r.Name)
+}
+
+func (r TLSRoute) GetName() string {
+	return r.Name
+}

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -24,12 +24,14 @@ type RpcPlugin struct {
 	HTTPRouteClient      gatewayApiClientv1.HTTPRouteInterface
 	TCPRouteClient       gatewayApiClientv1alpha2.TCPRouteInterface
 	GRPCRouteClient      gatewayApiClientv1.GRPCRouteInterface
+	TLSRouteClient       gatewayApiClientv1alpha2.TLSRouteInterface
 	TestClientset        v1.ConfigMapInterface
 	GatewayAPIClientset  *gatewayAPIClientset.Clientset
 	Clientset            *kubernetes.Clientset
 	UpdatedHTTPRouteMock *gatewayv1.HTTPRoute
 	UpdatedTCPRouteMock  *v1alpha2.TCPRoute
 	UpdatedGRPCRouteMock *gatewayv1.GRPCRoute
+	UpdatedTLSRouteMock  *v1alpha2.TLSRoute
 	LogCtx               *logrus.Entry
 	IsTest               bool
 }
@@ -44,6 +46,9 @@ type GatewayAPITrafficRouting struct {
 	// TCPRoute refers to the name of the TCPRoute used to route traffic to the
 	// service
 	TCPRoute string `json:"tcpRoute,omitempty"`
+	// TLSRoute refers to the name of the TLSRoute used to route traffic to the
+	// service
+	TLSRoute string `json:"tlsRoute,omitempty"`
 	// Namespace refers to the namespace of the specified resource
 	Namespace string `json:"namespace,omitempty"`
 	// ConfigMap refers to the config map where plugin stores data about managed routes
@@ -57,12 +62,17 @@ type GatewayAPITrafficRouting struct {
 	// GRPCRoutes refer to names of GRPCRoute resources used to route traffic to the
 	// service
 	GRPCRoutes []GRPCRoute `json:"grpcRoutes,omitempty"`
+	// TLSRoutes refer to names of TLSRoute resources used to route traffic to the
+	// service
+	TLSRoutes []TLSRoute `json:"tlsRoutes,omitempty"`
 	// HTTPRouteSelector refers to label selector for auto-discovery of HTTPRoutes
 	HTTPRouteSelector *metav1.LabelSelector `json:"httpRouteSelector,omitempty"`
 	// GRPCRouteSelector refers to label selector for auto-discovery of GRPCRoutes
 	GRPCRouteSelector *metav1.LabelSelector `json:"grpcRouteSelector,omitempty"`
 	// TCPRouteSelector refers to label selector for auto-discovery of TCPRoutes
 	TCPRouteSelector *metav1.LabelSelector `json:"tcpRouteSelector,omitempty"`
+	// TLSRouteSelector refers to label selector for auto-discovery of TLSRoutes
+	TLSRouteSelector *metav1.LabelSelector `json:"tlsRouteSelector,omitempty"`
 	// ConfigMapRWMutex refers to the RWMutex that we use to enter to the critical section
 	// critical section is config map
 	ConfigMapRWMutex sync.RWMutex
@@ -92,6 +102,14 @@ type GRPCRoute struct {
 	UseHeaderRoutes bool `json:"useHeaderRoutes"`
 }
 
+type TLSRoute struct {
+	// Name refers to the TLSRoute name
+	Name string `json:"name" validate:"required"`
+	// UseHeaderRoutes indicates header routes will be added to this route or not
+	// during setHeaderRoute step
+	UseHeaderRoutes bool `json:"useHeaderRoutes"`
+}
+
 type ManagedRouteMap map[string]map[string]int
 
 type HTTPRouteRule gatewayv1.HTTPRouteRule
@@ -100,11 +118,15 @@ type GRPCRouteRule gatewayv1.GRPCRouteRule
 
 type TCPRouteRule v1alpha2.TCPRouteRule
 
+type TLSRouteRule v1alpha2.TLSRouteRule
+
 type HTTPRouteRuleList []gatewayv1.HTTPRouteRule
 
 type GRPCRouteRuleList []gatewayv1.GRPCRouteRule
 
 type TCPRouteRuleList []v1alpha2.TCPRouteRule
+
+type TLSRouteRuleList []v1alpha2.TLSRouteRule
 
 type HTTPBackendRef gatewayv1.HTTPBackendRef
 
@@ -112,24 +134,26 @@ type GRPCBackendRef gatewayv1.GRPCBackendRef
 
 type TCPBackendRef gatewayv1.BackendRef
 
+type TLSBackendRef gatewayv1.BackendRef
+
 type GatewayAPIRoute interface {
-	HTTPRoute | GRPCRoute | TCPRoute
+	HTTPRoute | GRPCRoute | TCPRoute | TLSRoute
 	GetName() string
 }
 
 type GatewayAPIRouteRule[T1 GatewayAPIBackendRef] interface {
-	*HTTPRouteRule | *GRPCRouteRule | *TCPRouteRule
+	*HTTPRouteRule | *GRPCRouteRule | *TCPRouteRule | *TLSRouteRule
 	Iterator() (GatewayAPIRouteRuleIterator[T1], bool)
 }
 
 type GatewayAPIRouteRuleList[T1 GatewayAPIBackendRef, T2 GatewayAPIRouteRule[T1]] interface {
-	HTTPRouteRuleList | GRPCRouteRuleList | TCPRouteRuleList
+	HTTPRouteRuleList | GRPCRouteRuleList | TCPRouteRuleList | TLSRouteRuleList
 	Iterator() (GatewayAPIRouteRuleListIterator[T1, T2], bool)
 	Error() error
 }
 
 type GatewayAPIBackendRef interface {
-	*HTTPBackendRef | *GRPCBackendRef | *TCPBackendRef
+	*HTTPBackendRef | *GRPCBackendRef | *TCPBackendRef | *TLSBackendRef
 	GetName() string
 }
 

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -23,6 +23,10 @@ const (
 	TCP_ROUTE_BASIC_PATH         = "./testdata/tcproute-basic.yml"
 	TCP_ROUTE_BASIC_ROLLOUT_PATH = "./testdata/single-tcproute-rollout.yml"
 
+	// TLS Route test paths
+	TLS_ROUTE_BASIC_PATH         = "./testdata/tlsroute-basic.yml"
+	TLS_ROUTE_BASIC_ROLLOUT_PATH = "./testdata/single-tlsroute-rollout.yml"
+
 	// HTTP Route filter test paths
 	HTTP_ROUTE_FILTERS_PATH         = "./testdata/httproute-filters.yml"
 	HTTP_ROUTE_FILTERS_ROLLOUT_PATH = "./testdata/single-httproute-filters-rollout.yml"
@@ -54,6 +58,7 @@ const (
 	HTTP_ROUTE_KEY = "httpRoute"
 	GRPC_ROUTE_KEY = "grpcRoute"
 	TCP_ROUTE_KEY  = "tcpRoute"
+	TLS_ROUTE_KEY  = "tlsRoute"
 	ROLLOUT_KEY    = "rollout"
 )
 

--- a/test/e2e/single_tlsroute_test.go
+++ b/test/e2e/single_tlsroute_test.go
@@ -1,0 +1,249 @@
+//go:build !flaky
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/e2e-framework/klient/decoder"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestSingleTLSRoute(t *testing.T) {
+	feature := features.New("Single TLSRoute feature").Setup(
+		setupEnvironment,
+	).Setup(
+		setupSingleTLSRouteEnv,
+	).Assess(
+		"Testing single TLSRoute feature",
+		testSingleTLSRoute,
+	).Teardown(
+		teardownSingleTLSRouteEnv,
+	).Feature()
+	_ = global.Test(t, feature)
+}
+
+func setupSingleTLSRouteEnv(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+	var tlsRoute v1alpha2.TLSRoute
+	var rollout v1alpha1.Rollout
+	clusterResources := config.Client().Resources()
+	resourcesMap := map[string]*unstructured.Unstructured{}
+	ctx = context.WithValue(ctx, RESOURCES_MAP_KEY, resourcesMap)
+	firstTLSRouteFile, err := os.Open(TLS_ROUTE_BASIC_PATH)
+	if err != nil {
+		logrus.Errorf("file %q openning was failed: %s", TLS_ROUTE_BASIC_PATH, err)
+		t.Error()
+		return ctx
+	}
+	defer firstTLSRouteFile.Close()
+	logrus.Infof("file %q was opened", TLS_ROUTE_BASIC_PATH)
+	rolloutFile, err := os.Open(TLS_ROUTE_BASIC_ROLLOUT_PATH)
+	if err != nil {
+		logrus.Errorf("file %q openning was failed: %s", TLS_ROUTE_BASIC_ROLLOUT_PATH, err)
+		t.Error()
+		return ctx
+	}
+	defer rolloutFile.Close()
+	logrus.Infof("file %q was opened", TLS_ROUTE_BASIC_ROLLOUT_PATH)
+	err = decoder.Decode(firstTLSRouteFile, &tlsRoute)
+	if err != nil {
+		logrus.Errorf("file %q decoding was failed: %s", TLS_ROUTE_BASIC_PATH, err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("file %q was decoded", TLS_ROUTE_BASIC_PATH)
+	err = decoder.Decode(rolloutFile, &rollout)
+	if err != nil {
+		logrus.Errorf("file %q decoding was failed: %s", TLS_ROUTE_BASIC_ROLLOUT_PATH, err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("file %q was decoded", TLS_ROUTE_BASIC_ROLLOUT_PATH)
+	tlsRouteObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&tlsRoute)
+	if err != nil {
+		logrus.Errorf("tlsRoute %q converting to unstructured was failed: %s", tlsRoute.GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("tlsRoute %q was converted to unstructured", tlsRoute.GetName())
+	resourcesMap[TLS_ROUTE_KEY] = &unstructured.Unstructured{
+		Object: tlsRouteObject,
+	}
+	rolloutObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&rollout)
+	if err != nil {
+		logrus.Errorf("rollout %q converting to unstructured was failed: %s", rollout.GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was converted to unstructured", rollout.GetName())
+	unstructured.RemoveNestedField(rolloutObject, "spec", "template", "metadata", "creationTimestamp")
+	resourcesMap[ROLLOUT_KEY] = &unstructured.Unstructured{
+		Object: rolloutObject,
+	}
+	err = clusterResources.Create(ctx, resourcesMap[TLS_ROUTE_KEY])
+	if err != nil {
+		logrus.Errorf("tlsRoute %q creation was failed: %s", resourcesMap[TLS_ROUTE_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("tlsRoute %q was created", resourcesMap[TLS_ROUTE_KEY].GetName())
+	err = clusterResources.Create(ctx, resourcesMap[ROLLOUT_KEY])
+	if err != nil {
+		logrus.Errorf("rollout %q creation was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was created", resourcesMap[ROLLOUT_KEY].GetName())
+	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for tlsRoute %q to connect with rollout %q (expecting canary weight: %d)", resourcesMap[TLS_ROUTE_KEY].GetName(), resourcesMap[ROLLOUT_KEY].GetName(), FIRST_CANARY_ROUTE_WEIGHT)
+	err = wait.For(
+		waitCondition.ResourceMatch(
+			resourcesMap[TLS_ROUTE_KEY],
+			getMatchTLSRouteFetcher(t, FIRST_CANARY_ROUTE_WEIGHT),
+		),
+		wait.WithTimeout(MEDIUM_PERIOD),
+		wait.WithInterval(SHORT_PERIOD),
+	)
+	if err != nil {
+		logrus.Errorf("checking tlsRoute %q connection with rollout %q was failed: %s", resourcesMap[TLS_ROUTE_KEY].GetName(), resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("tlsRoute %q connected with rollout %q", resourcesMap[TLS_ROUTE_KEY].GetName(), resourcesMap[ROLLOUT_KEY].GetName())
+	return ctx
+}
+
+func testSingleTLSRoute(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+	clusterResources := config.Client().Resources()
+	resourcesMap, ok := ctx.Value(RESOURCES_MAP_KEY).(map[string]*unstructured.Unstructured)
+	if !ok {
+		logrus.Errorf("%q type assertion was failed", RESOURCES_MAP_KEY)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("%q was type asserted", RESOURCES_MAP_KEY)
+	containersObject, isFound, err := unstructured.NestedFieldNoCopy(resourcesMap[ROLLOUT_KEY].Object, strings.Split(ROLLOUT_TEMPLATE_CONTAINERS_FIELD, ".")...)
+	if !isFound {
+		logrus.Errorf("rollout %q field %q was not found", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_CONTAINERS_FIELD)
+		t.Error()
+		return ctx
+	}
+	if err != nil {
+		logrus.Errorf("getting rollout %q field %q was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_CONTAINERS_FIELD, err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q field %q was received", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_CONTAINERS_FIELD)
+	unstructuredContainerList, ok := containersObject.([]interface{})
+	if !ok {
+		logrus.Errorf("rollout %q field %q type assertion was failed", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_CONTAINERS_FIELD)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q field %q was type asserted", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_CONTAINERS_FIELD)
+	unstructuredContainer, ok := unstructuredContainerList[0].(map[string]interface{})
+	if !ok {
+		logrus.Errorf("rollout %q field %q type assertion was failed", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_FIRST_CONTAINER_FIELD)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q field %q was type asserted", resourcesMap[ROLLOUT_KEY].GetName(), ROLLOUT_TEMPLATE_FIRST_CONTAINER_FIELD)
+	unstructured.RemoveNestedField(resourcesMap[ROLLOUT_KEY].Object, "metadata", "resourceVersion")
+	unstructuredContainer["image"] = NEW_IMAGE_FIELD_VALUE
+	serializedRollout, err := json.Marshal(resourcesMap[ROLLOUT_KEY].Object)
+	if err != nil {
+		logrus.Errorf("rollout %q serializing was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was serialized", resourcesMap[ROLLOUT_KEY].GetName())
+	rolloutPatch := k8s.Patch{
+		PatchType: types.MergePatchType,
+		Data:      serializedRollout,
+	}
+	err = clusterResources.Patch(ctx, resourcesMap[ROLLOUT_KEY], rolloutPatch)
+	if err != nil {
+		logrus.Errorf("rollout %q updating was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was updated", resourcesMap[ROLLOUT_KEY].GetName())
+	waitCondition := conditions.New(clusterResources)
+	logrus.Infof("waiting for tlsRoute %q to update canary weight to %d after rollout image change", resourcesMap[TLS_ROUTE_KEY].GetName(), LAST_CANARY_ROUTE_WEIGHT)
+	err = wait.For(
+		waitCondition.ResourceMatch(
+			resourcesMap[TLS_ROUTE_KEY],
+			getMatchTLSRouteFetcher(t, LAST_CANARY_ROUTE_WEIGHT),
+		),
+		wait.WithTimeout(LONG_PERIOD),
+		wait.WithInterval(SHORT_PERIOD),
+	)
+	if err != nil {
+		logrus.Errorf("tlsRoute %q updating failed: %s", resourcesMap[TLS_ROUTE_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("tlsRoute %q was updated", resourcesMap[TLS_ROUTE_KEY].GetName())
+	return ctx
+}
+
+func teardownSingleTLSRouteEnv(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
+	clusterResources := config.Client().Resources()
+	resourcesMap, ok := ctx.Value(RESOURCES_MAP_KEY).(map[string]*unstructured.Unstructured)
+	if !ok {
+		logrus.Errorf("%q type assertion was failed", RESOURCES_MAP_KEY)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("%q was type asserted", RESOURCES_MAP_KEY)
+	err := clusterResources.Delete(ctx, resourcesMap[ROLLOUT_KEY])
+	if err != nil {
+		logrus.Errorf("deleting rollout %q was failed: %s", resourcesMap[ROLLOUT_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("rollout %q was deleted", resourcesMap[ROLLOUT_KEY].GetName())
+	err = clusterResources.Delete(ctx, resourcesMap[TLS_ROUTE_KEY])
+	if err != nil {
+		logrus.Errorf("deleting tlsRoute %q was failed: %s", resourcesMap[TLS_ROUTE_KEY].GetName(), err)
+		t.Error()
+		return ctx
+	}
+	logrus.Infof("tlsRoute %q was deleted", resourcesMap[TLS_ROUTE_KEY].GetName())
+	return ctx
+}
+
+func getMatchTLSRouteFetcher(t *testing.T, targetWeight int32) func(k8s.Object) bool {
+	return func(obj k8s.Object) bool {
+		var tlsRoute v1alpha2.TLSRoute
+		unstructuredTLSRoute, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			logrus.Error("k8s object type assertion was failed")
+			t.Error()
+			return false
+		}
+		// logrus.Info("k8s object was type asserted")
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredTLSRoute.Object, &tlsRoute)
+		if err != nil {
+			logrus.Errorf("conversation from unstructured tlsRoute %q to the typed tlsRoute was failed", unstructuredTLSRoute.GetName())
+			t.Error()
+			return false
+		}
+		// logrus.Infof("unstructured tlsRoute %q was converted to the typed tlsRoute", tlsRoute.GetName())
+		return *tlsRoute.Spec.Rules[ROLLOUT_ROUTE_RULE_INDEX].BackendRefs[CANARY_BACKEND_REF_INDEX].Weight == targetWeight
+	}
+}

--- a/test/e2e/testdata/single-tlsroute-rollout.yml
+++ b/test/e2e/testdata/single-tlsroute-rollout.yml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: tlsroute-rollout
+  namespace: default
+spec:
+  replicas: 2
+  strategy:
+    canary:
+      canaryService: argo-rollouts-canary-service
+      stableService: argo-rollouts-stable-service
+      trafficRouting:
+        plugins:
+          argoproj-labs/gatewayAPI:
+            tlsRoute: tlsroute-basic
+            namespace: default
+      steps:
+        - setWeight: 30
+        - pause: { }
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: rollouts-demo
+  template:
+    metadata:
+      labels:
+        app: rollouts-demo
+    spec:
+      containers:
+        - name: rollouts-demo
+          image: argoproj/rollouts-demo:red
+          ports:
+            - name: https
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              memory: 32Mi
+              cpu: 5m

--- a/test/e2e/testdata/tlsroute-basic.yml
+++ b/test/e2e/testdata/tlsroute-basic.yml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tlsroute-basic
+  namespace: default
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      sectionName: tls
+      namespace: default
+      kind: Gateway
+  hostnames:
+    - "example.com"
+  rules:
+    - backendRefs:
+        - name: argo-rollouts-stable-service
+          port: 443
+        - name: argo-rollouts-canary-service
+          port: 443


### PR DESCRIPTION
Closes #135

## Summary
- Added support of TLSRoute

## Changes
- Added `TLSRoute` support for both: single route and list of routes
- Updated mocks for new route type
- Updated tests

## Configuration example
```
trafficRouting:
  plugins:
    argoproj-labs/gatewayAPI:
      tlsRoute: tlsroute-basic
      namespace: default
```