### PR TITLE
test: Run Parallel tests to make them faster

### DIFF
--- a/test/e2e/chainsaw/advanced-header-based-grpcroute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/advanced-header-based-grpcroute/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
     regardless of subsequent setWeight calls. This test creates two header routes at different
     weight stages (30% and 60%) and verifies they remain unchanged when weight increases to 90%.
   namespace: default
-  concurrent: false
+  concurrent: true
 
   steps:
     - name: create-resources

--- a/test/e2e/chainsaw/advanced-header-based-httproute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/advanced-header-based-httproute/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
     regardless of subsequent setWeight calls. This test creates two header routes at different
     weight stages (30% and 60%) and verifies they remain unchanged when weight increases to 90%.
   namespace: default
-  concurrent: false
+  concurrent: true
 
   steps:
     - name: create-resources

--- a/test/e2e/chainsaw/httproute-label/assertions/httproute-no-label.yaml
+++ b/test/e2e/chainsaw/httproute-label/assertions/httproute-no-label.yaml
@@ -1,6 +1,6 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: httproute-basic
+  name: httproute-label-basic
   namespace: default
   (contains(keys(labels || `{}`), 'rollouts.argoproj.io/gatewayapi-canary')): false

--- a/test/e2e/chainsaw/httproute-label/assertions/httproute-with-label.yaml
+++ b/test/e2e/chainsaw/httproute-label/assertions/httproute-with-label.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: httproute-basic
+  name: httproute-label-basic
   namespace: default
   labels:
     rollouts.argoproj.io/gatewayapi-canary: in-progress

--- a/test/e2e/chainsaw/httproute-label/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/httproute-label/chainsaw-test.yaml
@@ -11,7 +11,7 @@ spec:
     and removes it once the rollout completes.
   # Uses 'default' namespace so the gateway (traefik-gateway) is accessible.
   namespace: default
-  concurrent: false
+  concurrent: true
 
   steps:
     - name: create-resources

--- a/test/e2e/chainsaw/httproute-label/resources/httproute.yaml
+++ b/test/e2e/chainsaw/httproute-label/resources/httproute.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: httproute-basic
+  name: httproute-label-basic
   namespace: default
 spec:
   parentRefs:

--- a/test/e2e/chainsaw/httproute-label/resources/rollout.yaml
+++ b/test/e2e/chainsaw/httproute-label/resources/rollout.yaml
@@ -12,7 +12,7 @@ spec:
       trafficRouting:
         plugins:
           argoproj-labs/gatewayAPI:
-            httpRoute: httproute-basic
+            httpRoute: httproute-label-basic
             namespace: default
       steps:
         - setWeight: 30

--- a/test/e2e/chainsaw/single-grpcroute-filters/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/single-grpcroute-filters/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
     header-match rule when header-based routing is active.
   # Uses 'default' namespace so the gateway (traefik-gateway) is accessible.
   namespace: default
-  concurrent: false
+  concurrent: true
 
   steps:
     - name: create-resources

--- a/test/e2e/chainsaw/single-grpcroute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/single-grpcroute/chainsaw-test.yaml
@@ -11,7 +11,7 @@ spec:
     to 0 once the rollout completes.
   # Uses 'default' namespace so the gateway (traefik-gateway) is accessible.
   namespace: default
-  concurrent: false
+  concurrent: true
 
   steps:
     - name: create-resources

--- a/test/e2e/chainsaw/single-header-based-grpcroute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/single-header-based-grpcroute/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
     the rollout completes.
   # Uses 'default' namespace so the gateway (traefik-gateway) is accessible.
   namespace: default
-  concurrent: false
+  concurrent: true
 
   steps:
     - name: create-resources

--- a/test/e2e/chainsaw/single-header-based-httproute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/single-header-based-httproute/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
     the rollout completes.
   # Uses 'default' namespace so the gateway (traefik-gateway) is accessible.
   namespace: default
-  concurrent: false
+  concurrent: true
 
   steps:
     - name: create-resources

--- a/test/e2e/chainsaw/single-httproute-filters/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/single-httproute-filters/chainsaw-test.yaml
@@ -12,7 +12,7 @@ spec:
     header-match rule when header-based routing is active.
   # Uses 'default' namespace so the gateway (traefik-gateway) is accessible.
   namespace: default
-  concurrent: false
+  concurrent: true
 
   steps:
     - name: create-resources

--- a/test/e2e/chainsaw/single-httproute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/single-httproute/chainsaw-test.yaml
@@ -11,7 +11,7 @@ spec:
     to 0 once the rollout completes.
   # Uses 'default' namespace so the gateway (traefik-gateway) is accessible.
   namespace: default
-  concurrent: false
+  concurrent: true
 
   steps:
     - name: create-resources

--- a/test/e2e/chainsaw/single-tcproute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/single-tcproute/chainsaw-test.yaml
@@ -11,7 +11,7 @@ spec:
     to 0 once the rollout completes.
   # Uses 'default' namespace so the gateway (traefik-gateway) is accessible.
   namespace: default
-  concurrent: false
+  concurrent: true
 
   steps:
     - name: create-resources

--- a/test/e2e/chainsaw/single-tlsroute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/single-tlsroute/chainsaw-test.yaml
@@ -11,7 +11,7 @@ spec:
     to 0 once the rollout completes.
   # Uses 'default' namespace so the gateway (traefik-gateway) is accessible.
   namespace: default
-  concurrent: false
+  concurrent: true
 
   steps:
     - name: create-resources


### PR DESCRIPTION


## Description of this PR

Run all e2e tests in parallel to make them faster. Closes https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/issues/183

## Checklist:

* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] My build is green.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged
* [ ] The tests actually define testcases about the feature/fix implemented
* [x] I have run all tests locally and they pass
* [x] I haven't changed the existing tests in a significant way, as this will break functionality for existing users <sup>1</sup>
* [ ] I've updated documentation as required by this PR.
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY it works that way according to my use case
* [ ] I understand what the code does and HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My new code is using existing utility functions instead of re-implementing everything again
* [x] Optional. My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md)

Notes

1. Unless a discussion has happened already in an issue and the breaking change is deemed acceptable
