### PR TITLE
docs: add agentgateway to provider list

### DIFF
--- a/docs/provider-status.md
+++ b/docs/provider-status.md
@@ -21,6 +21,7 @@ For convenience we are including here a list of those actually tested with the p
 | [Google Cloud](https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api)     | N/A | 0.7.0      | 0.2.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/google-cloud)    |
 | [Istio](https://istio.io/)     | 1.29.1 | 1.4.0 | 0.11.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/istio)    |
 | [kgateway](https://kgateway.dev/)     | 2.2.2 | 1.4.0 | 0.11.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/kgateway)    |
+| [agentgateway](https://agentgateway.dev/)     | 1.0.1 | 1.5.0 | 0.11.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/agentgateway)    |
 | [Kong](https://docs.konghq.com/kubernetes-ingress-controller/latest/concepts/gateway-api/)     | 2.9.x  | 0.7.1    | 0.2.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/kong)    |
 | [Linkerd](https://linkerd.io/)     | edge-25.9.4 |   1.2.1    | 0.8.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/linkerd-header-based)    |
 | [NGINX Gateway](https://github.com/nginxinc/nginx-gateway-fabric)     | Unknown | 0.8.0      | 0.2.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/nginx)    |

--- a/docs/provider-status.md
+++ b/docs/provider-status.md
@@ -15,13 +15,13 @@ For convenience we are including here a list of those actually tested with the p
 
 | Provider   |    Version | API Version | Plugin   | Code     |
 |------------|------------|-------------| ---------| ---------|
+| [agentgateway](https://agentgateway.dev/)     | 1.0.1 | 1.5.0 | 0.11.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/agentgateway)    |
 | [Amazon VPC Lattice](https://www.gateway-api-controller.eks.aws.dev/latest//)     | 1.1.2 |   1.3.0    | 0.6.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/aws-gateway-api-controller-lattice )    |
 | [Cilium](https://cilium.io/)     | 1.18.2 | 1.2.0 | 0.8.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/cilium-header-based)    |
 | [Envoy Gateway](https://gateway.envoyproxy.io/)     | 0.5.0  |   Unknown  | 0.2.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/envoygateway)    |
 | [Google Cloud](https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api)     | N/A | 0.7.0      | 0.2.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/google-cloud)    |
 | [Istio](https://istio.io/)     | 1.29.1 | 1.4.0 | 0.11.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/istio)    |
 | [kgateway](https://kgateway.dev/)     | 2.2.2 | 1.4.0 | 0.11.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/kgateway)    |
-| [agentgateway](https://agentgateway.dev/)     | 1.0.1 | 1.5.0 | 0.11.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/agentgateway)    |
 | [Kong](https://docs.konghq.com/kubernetes-ingress-controller/latest/concepts/gateway-api/)     | 2.9.x  | 0.7.1    | 0.2.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/kong)    |
 | [Linkerd](https://linkerd.io/)     | edge-25.9.4 |   1.2.1    | 0.8.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/linkerd-header-based)    |
 | [NGINX Gateway](https://github.com/nginxinc/nginx-gateway-fabric)     | Unknown | 0.8.0      | 0.2.0 | [Example](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/tree/main/examples/nginx)    |


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Description of this PR

This PR is part of the Mentorship Program: https://github.com/kgateway-dev/kgateway.dev/issues/606
It builds on the work in the PR https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/pull/186, where a agentgateway example was added. In this PR, the provider list has been updated.
