### PR TITLE
test: remove test conditionals

### DIFF
--- a/pkg/plugin/experiment.go
+++ b/pkg/plugin/experiment.go
@@ -12,7 +12,7 @@ import (
 	gatewayApiClientset "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 )
 
-func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gatewayClient *gatewayApiClientset.Clientset, logger *logrus.Entry, rollout *v1alpha1.Rollout, httpRoute *gatewayv1.HTTPRoute, additionalDestinations []v1alpha1.WeightDestination) error {
+func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gatewayClient gatewayApiClientset.Interface, logger *logrus.Entry, rollout *v1alpha1.Rollout, httpRoute *gatewayv1.HTTPRoute, additionalDestinations []v1alpha1.WeightDestination) error {
 	ruleIdx := -1
 	stableService := rollout.Spec.Strategy.Canary.StableService
 	canaryService := rollout.Spec.Strategy.Canary.CanaryService

--- a/pkg/plugin/grpcroute.go
+++ b/pkg/plugin/grpcroute.go
@@ -13,11 +13,7 @@ import (
 
 func (r *RpcPlugin) setGRPCRouteWeight(rollout *v1alpha1.Rollout, desiredWeight int32, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
 	ctx := context.TODO()
-	grpcRouteClient := r.GRPCRouteClient
-	if !r.IsTest {
-		gatewayClientv1 := r.GatewayAPIClientset.GatewayV1()
-		grpcRouteClient = gatewayClientv1.GRPCRoutes(gatewayAPIConfig.Namespace)
-	}
+	grpcRouteClient := r.GatewayAPIClientset.GatewayV1().GRPCRoutes(gatewayAPIConfig.Namespace)
 
 	canaryServiceName := rollout.Spec.Strategy.Canary.CanaryService
 	stableServiceName := rollout.Spec.Strategy.Canary.StableService
@@ -25,7 +21,6 @@ func (r *RpcPlugin) setGRPCRouteWeight(rollout *v1alpha1.Rollout, desiredWeight 
 	restWeight := 100 - desiredWeight
 	managedNames := managedRouteNamesSet(rollout)
 
-	var updatedGRPCRoute *gatewayv1.GRPCRoute
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		grpcRoute, err := grpcRouteClient.Get(ctx, gatewayAPIConfig.GRPCRoute, metav1.GetOptions{})
 		if err != nil {
@@ -59,13 +54,10 @@ func (r *RpcPlugin) setGRPCRouteWeight(rollout *v1alpha1.Rollout, desiredWeight 
 
 		ensureInProgressLabel(grpcRoute, desiredWeight, gatewayAPIConfig)
 
-		updatedGRPCRoute, err = grpcRouteClient.Update(ctx, grpcRoute, metav1.UpdateOptions{})
+		_, err = grpcRouteClient.Update(ctx, grpcRoute, metav1.UpdateOptions{})
 		return err
 	})
 
-	if r.IsTest {
-		r.UpdatedGRPCRouteMock = updatedGRPCRoute
-	}
 	if err != nil {
 		return pluginTypes.RpcError{
 			ErrorString: err.Error(),
@@ -79,11 +71,7 @@ func (r *RpcPlugin) setGRPCHeaderRoute(rollout *v1alpha1.Rollout, headerRouting 
 		return r.removeGRPCManagedRoutes(rollout, gatewayAPIConfig)
 	}
 	ctx := context.TODO()
-	grpcRouteClient := r.GRPCRouteClient
-	if !r.IsTest {
-		gatewayClientV1 := r.GatewayAPIClientset.GatewayV1()
-		grpcRouteClient = gatewayClientV1.GRPCRoutes(gatewayAPIConfig.Namespace)
-	}
+	grpcRouteClient := r.GatewayAPIClientset.GatewayV1().GRPCRoutes(gatewayAPIConfig.Namespace)
 	grpcHeaderRouteRuleList, rpcError := getGRPCHeaderRouteRuleList(headerRouting)
 	if rpcError.HasError() {
 		return rpcError
@@ -93,7 +81,6 @@ func (r *RpcPlugin) setGRPCHeaderRoute(rollout *v1alpha1.Rollout, headerRouting 
 	stableServiceName := rollout.Spec.Strategy.Canary.StableService
 	managedName := gatewayv1.SectionName(headerRouting.Name)
 
-	var updatedGRPCRoute *gatewayv1.GRPCRoute
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		grpcRoute, err := grpcRouteClient.Get(ctx, gatewayAPIConfig.GRPCRoute, metav1.GetOptions{})
 		if err != nil {
@@ -183,13 +170,10 @@ func (r *RpcPlugin) setGRPCHeaderRoute(rollout *v1alpha1.Rollout, headerRouting 
 		}
 		grpcRoute.Spec.Rules = grpcRouteRuleList
 
-		updatedGRPCRoute, err = grpcRouteClient.Update(ctx, grpcRoute, metav1.UpdateOptions{})
+		_, err = grpcRouteClient.Update(ctx, grpcRoute, metav1.UpdateOptions{})
 		return err
 	})
 
-	if r.IsTest {
-		r.UpdatedGRPCRouteMock = updatedGRPCRoute
-	}
 	if err != nil {
 		return pluginTypes.RpcError{
 			ErrorString: err.Error(),
@@ -267,16 +251,11 @@ func getGRPCHeaderRouteRuleList(headerRouting *v1alpha1.SetHeaderRoute) ([]gatew
 
 func (r *RpcPlugin) removeGRPCManagedRoutes(rollout *v1alpha1.Rollout, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
 	ctx := context.TODO()
-	grpcRouteClient := r.GRPCRouteClient
-	if !r.IsTest {
-		gatewayClientv1 := r.GatewayAPIClientset.GatewayV1()
-		grpcRouteClient = gatewayClientv1.GRPCRoutes(gatewayAPIConfig.Namespace)
-	}
+	grpcRouteClient := r.GatewayAPIClientset.GatewayV1().GRPCRoutes(gatewayAPIConfig.Namespace)
 
 	canaryServiceName := gatewayv1.ObjectName(rollout.Spec.Strategy.Canary.CanaryService)
 	managedNames := managedRouteNamesSet(rollout)
 
-	var updatedGRPCRoute *gatewayv1.GRPCRoute
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		grpcRoute, err := grpcRouteClient.Get(ctx, gatewayAPIConfig.GRPCRoute, metav1.GetOptions{})
 		if err != nil {
@@ -298,13 +277,10 @@ func (r *RpcPlugin) removeGRPCManagedRoutes(rollout *v1alpha1.Rollout, gatewayAP
 		}
 		grpcRoute.Spec.Rules = newRules
 
-		updatedGRPCRoute, err = grpcRouteClient.Update(ctx, grpcRoute, metav1.UpdateOptions{})
+		_, err = grpcRouteClient.Update(ctx, grpcRoute, metav1.UpdateOptions{})
 		return err
 	})
 
-	if r.IsTest {
-		r.UpdatedGRPCRouteMock = updatedGRPCRoute
-	}
 	if err != nil {
 		return pluginTypes.RpcError{
 			ErrorString: err.Error(),

--- a/pkg/plugin/httproute.go
+++ b/pkg/plugin/httproute.go
@@ -13,11 +13,7 @@ import (
 
 func (r *RpcPlugin) setHTTPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight int32, additionalDestinations []v1alpha1.WeightDestination, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
 	ctx := context.TODO()
-	httpRouteClient := r.HTTPRouteClient
-	if !r.IsTest {
-		gatewayClientV1 := r.GatewayAPIClientset.GatewayV1()
-		httpRouteClient = gatewayClientV1.HTTPRoutes(gatewayAPIConfig.Namespace)
-	}
+	httpRouteClient := r.GatewayAPIClientset.GatewayV1().HTTPRoutes(gatewayAPIConfig.Namespace)
 
 	canaryServiceName := rollout.Spec.Strategy.Canary.CanaryService
 	stableServiceName := rollout.Spec.Strategy.Canary.StableService
@@ -25,7 +21,6 @@ func (r *RpcPlugin) setHTTPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight 
 	restWeight := 100 - desiredWeight
 	managedNames := managedRouteNamesSet(rollout)
 
-	var updatedHTTPRoute *gatewayv1.HTTPRoute
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		httpRoute, err := httpRouteClient.Get(ctx, gatewayAPIConfig.HTTPRoute, metav1.GetOptions{})
 		if err != nil {
@@ -64,13 +59,10 @@ func (r *RpcPlugin) setHTTPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight 
 
 		ensureInProgressLabel(httpRoute, desiredWeight, gatewayAPIConfig)
 
-		updatedHTTPRoute, err = httpRouteClient.Update(ctx, httpRoute, metav1.UpdateOptions{})
+		_, err = httpRouteClient.Update(ctx, httpRoute, metav1.UpdateOptions{})
 		return err
 	})
 
-	if r.IsTest {
-		r.UpdatedHTTPRouteMock = updatedHTTPRoute
-	}
 	if err != nil {
 		return pluginTypes.RpcError{
 			ErrorString: err.Error(),
@@ -84,11 +76,7 @@ func (r *RpcPlugin) setHTTPHeaderRoute(rollout *v1alpha1.Rollout, headerRouting 
 		return r.removeHTTPManagedRoutes(rollout, gatewayAPIConfig)
 	}
 	ctx := context.TODO()
-	httpRouteClient := r.HTTPRouteClient
-	if !r.IsTest {
-		gatewayClientv1 := r.GatewayAPIClientset.GatewayV1()
-		httpRouteClient = gatewayClientv1.HTTPRoutes(gatewayAPIConfig.Namespace)
-	}
+	httpRouteClient := r.GatewayAPIClientset.GatewayV1().HTTPRoutes(gatewayAPIConfig.Namespace)
 	httpHeaderRouteRuleList, rpcError := getHTTPHeaderRouteRuleList(headerRouting)
 	if rpcError.HasError() {
 		return rpcError
@@ -98,7 +86,6 @@ func (r *RpcPlugin) setHTTPHeaderRoute(rollout *v1alpha1.Rollout, headerRouting 
 	stableServiceName := rollout.Spec.Strategy.Canary.StableService
 	managedName := gatewayv1.SectionName(headerRouting.Name)
 
-	var updatedHTTPRoute *gatewayv1.HTTPRoute
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		httpRoute, err := httpRouteClient.Get(ctx, gatewayAPIConfig.HTTPRoute, metav1.GetOptions{})
 		if err != nil {
@@ -192,13 +179,10 @@ func (r *RpcPlugin) setHTTPHeaderRoute(rollout *v1alpha1.Rollout, headerRouting 
 		}
 		httpRoute.Spec.Rules = httpRouteRuleList
 
-		updatedHTTPRoute, err = httpRouteClient.Update(ctx, httpRoute, metav1.UpdateOptions{})
+		_, err = httpRouteClient.Update(ctx, httpRoute, metav1.UpdateOptions{})
 		return err
 	})
 
-	if r.IsTest {
-		r.UpdatedHTTPRouteMock = updatedHTTPRoute
-	}
 	if err != nil {
 		return pluginTypes.RpcError{
 			ErrorString: err.Error(),
@@ -276,16 +260,11 @@ func getHTTPHeaderRouteRuleList(headerRouting *v1alpha1.SetHeaderRoute) ([]gatew
 
 func (r *RpcPlugin) removeHTTPManagedRoutes(rollout *v1alpha1.Rollout, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
 	ctx := context.TODO()
-	httpRouteClient := r.HTTPRouteClient
-	if !r.IsTest {
-		gatewayClientv1 := r.GatewayAPIClientset.GatewayV1()
-		httpRouteClient = gatewayClientv1.HTTPRoutes(gatewayAPIConfig.Namespace)
-	}
+	httpRouteClient := r.GatewayAPIClientset.GatewayV1().HTTPRoutes(gatewayAPIConfig.Namespace)
 
 	canaryServiceName := gatewayv1.ObjectName(rollout.Spec.Strategy.Canary.CanaryService)
 	managedNames := managedRouteNamesSet(rollout)
 
-	var updatedHTTPRoute *gatewayv1.HTTPRoute
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		httpRoute, err := httpRouteClient.Get(ctx, gatewayAPIConfig.HTTPRoute, metav1.GetOptions{})
 		if err != nil {
@@ -307,13 +286,10 @@ func (r *RpcPlugin) removeHTTPManagedRoutes(rollout *v1alpha1.Rollout, gatewayAP
 		}
 		httpRoute.Spec.Rules = newRules
 
-		updatedHTTPRoute, err = httpRouteClient.Update(ctx, httpRoute, metav1.UpdateOptions{})
+		_, err = httpRouteClient.Update(ctx, httpRoute, metav1.UpdateOptions{})
 		return err
 	})
 
-	if r.IsTest {
-		r.UpdatedHTTPRouteMock = updatedHTTPRoute
-	}
 	if err != nil {
 		return pluginTypes.RpcError{
 			ErrorString: err.Error(),

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -23,9 +23,6 @@ const (
 func (r *RpcPlugin) InitPlugin() pluginTypes.RpcError {
 	log := utils.SetupLog()
 
-	if r.IsTest {
-		return pluginTypes.RpcError{}
-	}
 	kubeConfig, err := utils.GetKubeConfig()
 	if err != nil {
 		return pluginTypes.RpcError{
@@ -59,6 +56,7 @@ func (r *RpcPlugin) InitPlugin() pluginTypes.RpcError {
 	r.Clientset = clientset
 	return pluginTypes.RpcError{}
 }
+
 
 func (r *RpcPlugin) UpdateHash(rollout *v1alpha1.Rollout, canaryHash, stableHash string, additionalDestinations []v1alpha1.WeightDestination) pluginTypes.RpcError {
 	return pluginTypes.RpcError{}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -57,7 +57,6 @@ func (r *RpcPlugin) InitPlugin() pluginTypes.RpcError {
 	return pluginTypes.RpcError{}
 }
 
-
 func (r *RpcPlugin) UpdateHash(rollout *v1alpha1.Rollout, canaryHash, stableHash string, additionalDestinations []v1alpha1.WeightDestination) pluginTypes.RpcError {
 	return pluginTypes.RpcError{}
 }

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -31,12 +31,8 @@ func TestRunSuccessfully(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:          utils.SetupLog(),
-		IsTest:          true,
-		HTTPRouteClient: gwFake.NewSimpleClientset(&mocks.HTTPRouteObj).GatewayV1().HTTPRoutes(mocks.RolloutNamespace),
-		GRPCRouteClient: gwFake.NewSimpleClientset(&mocks.GRPCRouteObj).GatewayV1().GRPCRoutes(mocks.RolloutNamespace),
-		TCPRouteClient:  gwFake.NewSimpleClientset(&mocks.TCPPRouteObj).GatewayV1alpha2().TCPRoutes(mocks.RolloutNamespace),
-		TLSRouteClient:  gwFake.NewSimpleClientset(&mocks.TLSRouteObj).GatewayV1alpha2().TLSRoutes(mocks.RolloutNamespace),
+		LogCtx:              utils.SetupLog(),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(&mocks.HTTPRouteObj, &mocks.GRPCRouteObj, &mocks.TCPPRouteObj, &mocks.TLSRouteObj),
 	}
 
 	// pluginMap is the map of plugins we can dispense.
@@ -97,10 +93,6 @@ func TestRunSuccessfully(t *testing.T) {
 	}
 
 	pluginInstance := raw.(*rolloutsPlugin.TrafficRouterPluginRPC)
-	err = pluginInstance.InitPlugin()
-	if err.Error() != "" {
-		t.Fail()
-	}
 	t.Run("SetHTTPRouteWeight", func(t *testing.T) {
 		var desiredWeight int32 = 30
 		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
@@ -110,12 +102,14 @@ func TestRunSuccessfully(t *testing.T) {
 		err := pluginInstance.SetWeight(rollout, desiredWeight, []v1alpha1.WeightDestination{})
 
 		assert.Empty(t, err.Error())
-		assert.Equal(t, 100-desiredWeight, *(rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[0].BackendRefs[0].Weight))
-		assert.Equal(t, desiredWeight, *(rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[0].BackendRefs[1].Weight))
+		updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, 100-desiredWeight, *(updatedHTTP.Spec.Rules[0].BackendRefs[0].Weight))
+		assert.Equal(t, desiredWeight, *(updatedHTTP.Spec.Rules[0].BackendRefs[1].Weight))
 	})
 	t.Run("SetHTTPRouteWeightAddsAndRemovesLabel", func(t *testing.T) {
 		httpRoute := mocks.CreateHTTPRouteWithLabels(mocks.HTTPRouteName, nil)
-		rpcPluginImp.HTTPRouteClient = gwFake.NewSimpleClientset(httpRoute).GatewayV1().HTTPRoutes(mocks.RolloutNamespace)
+		rpcPluginImp.GatewayAPIClientset = gwFake.NewSimpleClientset(httpRoute, &mocks.GRPCRouteObj, &mocks.TCPPRouteObj, &mocks.TLSRouteObj)
 		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
 			Namespace: mocks.RolloutNamespace,
 			HTTPRoute: mocks.HTTPRouteName,
@@ -123,13 +117,15 @@ func TestRunSuccessfully(t *testing.T) {
 
 		err := pluginInstance.SetWeight(rollout, 25, []v1alpha1.WeightDestination{})
 		assert.Empty(t, err.Error())
-		labels := rpcPluginImp.UpdatedHTTPRouteMock.Labels
-		assert.Equal(t, defaults.InProgressLabelValue, labels[defaults.InProgressLabelKey])
+		updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, defaults.InProgressLabelValue, updatedHTTP.Labels[defaults.InProgressLabelKey])
 
 		err = pluginInstance.SetWeight(rollout, 0, []v1alpha1.WeightDestination{})
 		assert.Empty(t, err.Error())
-		labels = rpcPluginImp.UpdatedHTTPRouteMock.Labels
-		_, exists := labels[defaults.InProgressLabelKey]
+		updatedHTTP, getErr = rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		_, exists := updatedHTTP.Labels[defaults.InProgressLabelKey]
 		assert.False(t, exists)
 	})
 	t.Run("SetGRPCRouteWeight", func(t *testing.T) {
@@ -141,12 +137,14 @@ func TestRunSuccessfully(t *testing.T) {
 		err := pluginInstance.SetWeight(rollout, desiredWeight, []v1alpha1.WeightDestination{})
 
 		assert.Empty(t, err.Error())
-		assert.Equal(t, 100-desiredWeight, *(rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[0].BackendRefs[0].Weight))
-		assert.Equal(t, desiredWeight, *(rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[0].BackendRefs[1].Weight))
+		updatedGRPC, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, 100-desiredWeight, *(updatedGRPC.Spec.Rules[0].BackendRefs[0].Weight))
+		assert.Equal(t, desiredWeight, *(updatedGRPC.Spec.Rules[0].BackendRefs[1].Weight))
 	})
 	t.Run("SetGRPCRouteWeightAddsAndRemovesLabel", func(t *testing.T) {
 		grpcRoute := mocks.CreateGRPCRouteWithLabels(mocks.GRPCRouteName, nil)
-		rpcPluginImp.GRPCRouteClient = gwFake.NewSimpleClientset(grpcRoute).GatewayV1().GRPCRoutes(mocks.RolloutNamespace)
+		rpcPluginImp.GatewayAPIClientset = gwFake.NewSimpleClientset(&mocks.HTTPRouteObj, grpcRoute, &mocks.TCPPRouteObj, &mocks.TLSRouteObj)
 		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
 			Namespace: mocks.RolloutNamespace,
 			GRPCRoute: mocks.GRPCRouteName,
@@ -154,13 +152,15 @@ func TestRunSuccessfully(t *testing.T) {
 
 		err := pluginInstance.SetWeight(rollout, 40, []v1alpha1.WeightDestination{})
 		assert.Empty(t, err.Error())
-		labels := rpcPluginImp.UpdatedGRPCRouteMock.Labels
-		assert.Equal(t, defaults.InProgressLabelValue, labels[defaults.InProgressLabelKey])
+		updatedGRPC, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, defaults.InProgressLabelValue, updatedGRPC.Labels[defaults.InProgressLabelKey])
 
 		err = pluginInstance.SetWeight(rollout, 0, []v1alpha1.WeightDestination{})
 		assert.Empty(t, err.Error())
-		labels = rpcPluginImp.UpdatedGRPCRouteMock.Labels
-		_, exists := labels[defaults.InProgressLabelKey]
+		updatedGRPC, getErr = rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		_, exists := updatedGRPC.Labels[defaults.InProgressLabelKey]
 		assert.False(t, exists)
 	})
 	t.Run("SetTCPRouteWeight", func(t *testing.T) {
@@ -173,12 +173,14 @@ func TestRunSuccessfully(t *testing.T) {
 		err := pluginInstance.SetWeight(rollout, desiredWeight, []v1alpha1.WeightDestination{})
 
 		assert.Empty(t, err.Error())
-		assert.Equal(t, 100-desiredWeight, *(rpcPluginImp.UpdatedTCPRouteMock.Spec.Rules[0].BackendRefs[0].Weight))
-		assert.Equal(t, desiredWeight, *(rpcPluginImp.UpdatedTCPRouteMock.Spec.Rules[0].BackendRefs[1].Weight))
+		updatedTCP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1alpha2().TCPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.TCPRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, 100-desiredWeight, *(updatedTCP.Spec.Rules[0].BackendRefs[0].Weight))
+		assert.Equal(t, desiredWeight, *(updatedTCP.Spec.Rules[0].BackendRefs[1].Weight))
 	})
 	t.Run("SetTCPRouteWeightAddsAndRemovesLabel", func(t *testing.T) {
 		tcpRoute := mocks.CreateTCPRouteWithLabels(mocks.TCPRouteName, nil)
-		rpcPluginImp.TCPRouteClient = gwFake.NewSimpleClientset(tcpRoute).GatewayV1alpha2().TCPRoutes(mocks.RolloutNamespace)
+		rpcPluginImp.GatewayAPIClientset = gwFake.NewSimpleClientset(&mocks.HTTPRouteObj, &mocks.GRPCRouteObj, tcpRoute, &mocks.TLSRouteObj)
 		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName,
 			&GatewayAPITrafficRouting{
 				Namespace: mocks.RolloutNamespace,
@@ -187,13 +189,15 @@ func TestRunSuccessfully(t *testing.T) {
 
 		err := pluginInstance.SetWeight(rollout, 15, []v1alpha1.WeightDestination{})
 		assert.Empty(t, err.Error())
-		labels := rpcPluginImp.UpdatedTCPRouteMock.Labels
-		assert.Equal(t, defaults.InProgressLabelValue, labels[defaults.InProgressLabelKey])
+		updatedTCP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1alpha2().TCPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.TCPRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, defaults.InProgressLabelValue, updatedTCP.Labels[defaults.InProgressLabelKey])
 
 		err = pluginInstance.SetWeight(rollout, 0, []v1alpha1.WeightDestination{})
 		assert.Empty(t, err.Error())
-		labels = rpcPluginImp.UpdatedTCPRouteMock.Labels
-		_, exists := labels[defaults.InProgressLabelKey]
+		updatedTCP, getErr = rpcPluginImp.GatewayAPIClientset.GatewayV1alpha2().TCPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.TCPRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		_, exists := updatedTCP.Labels[defaults.InProgressLabelKey]
 		assert.False(t, exists)
 	})
 	t.Run("SetTLSRouteWeight", func(t *testing.T) {
@@ -206,12 +210,14 @@ func TestRunSuccessfully(t *testing.T) {
 		err := pluginInstance.SetWeight(rollout, desiredWeight, []v1alpha1.WeightDestination{})
 
 		assert.Empty(t, err.Error())
-		assert.Equal(t, 100-desiredWeight, *(rpcPluginImp.UpdatedTLSRouteMock.Spec.Rules[0].BackendRefs[0].Weight))
-		assert.Equal(t, desiredWeight, *(rpcPluginImp.UpdatedTLSRouteMock.Spec.Rules[0].BackendRefs[1].Weight))
+		updatedTLS, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1alpha2().TLSRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.TLSRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, 100-desiredWeight, *(updatedTLS.Spec.Rules[0].BackendRefs[0].Weight))
+		assert.Equal(t, desiredWeight, *(updatedTLS.Spec.Rules[0].BackendRefs[1].Weight))
 	})
 	t.Run("SetTLSRouteWeightAddsAndRemovesLabel", func(t *testing.T) {
 		tlsRoute := mocks.CreateTLSRouteWithLabels(mocks.TLSRouteName, nil)
-		rpcPluginImp.TLSRouteClient = gwFake.NewSimpleClientset(tlsRoute).GatewayV1alpha2().TLSRoutes(mocks.RolloutNamespace)
+		rpcPluginImp.GatewayAPIClientset = gwFake.NewSimpleClientset(&mocks.HTTPRouteObj, &mocks.GRPCRouteObj, &mocks.TCPPRouteObj, tlsRoute)
 		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName,
 			&GatewayAPITrafficRouting{
 				Namespace: mocks.RolloutNamespace,
@@ -220,13 +226,15 @@ func TestRunSuccessfully(t *testing.T) {
 
 		err := pluginInstance.SetWeight(rollout, 60, []v1alpha1.WeightDestination{})
 		assert.Empty(t, err.Error())
-		labels := rpcPluginImp.UpdatedTLSRouteMock.Labels
-		assert.Equal(t, defaults.InProgressLabelValue, labels[defaults.InProgressLabelKey])
+		updatedTLS, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1alpha2().TLSRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.TLSRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, defaults.InProgressLabelValue, updatedTLS.Labels[defaults.InProgressLabelKey])
 
 		err = pluginInstance.SetWeight(rollout, 0, []v1alpha1.WeightDestination{})
 		assert.Empty(t, err.Error())
-		labels = rpcPluginImp.UpdatedTLSRouteMock.Labels
-		_, exists := labels[defaults.InProgressLabelKey]
+		updatedTLS, getErr = rpcPluginImp.GatewayAPIClientset.GatewayV1alpha2().TLSRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.TLSRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		_, exists := updatedTLS.Labels[defaults.InProgressLabelKey]
 		assert.False(t, exists)
 	})
 	t.Run("SetWeightViaRoutes", func(t *testing.T) {
@@ -256,12 +264,18 @@ func TestRunSuccessfully(t *testing.T) {
 		err := pluginInstance.SetWeight(rollout, desiredWeight, []v1alpha1.WeightDestination{})
 
 		assert.Empty(t, err.Error())
-		assert.Equal(t, 100-desiredWeight, *(rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[0].BackendRefs[0].Weight))
-		assert.Equal(t, desiredWeight, *(rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[0].BackendRefs[1].Weight))
-		assert.Equal(t, 100-desiredWeight, *(rpcPluginImp.UpdatedTCPRouteMock.Spec.Rules[0].BackendRefs[0].Weight))
-		assert.Equal(t, desiredWeight, *(rpcPluginImp.UpdatedTCPRouteMock.Spec.Rules[0].BackendRefs[1].Weight))
-		assert.Equal(t, 100-desiredWeight, *(rpcPluginImp.UpdatedTLSRouteMock.Spec.Rules[0].BackendRefs[0].Weight))
-		assert.Equal(t, desiredWeight, *(rpcPluginImp.UpdatedTLSRouteMock.Spec.Rules[0].BackendRefs[1].Weight))
+		updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, 100-desiredWeight, *(updatedHTTP.Spec.Rules[0].BackendRefs[0].Weight))
+		assert.Equal(t, desiredWeight, *(updatedHTTP.Spec.Rules[0].BackendRefs[1].Weight))
+		updatedTCP, getErr2 := rpcPluginImp.GatewayAPIClientset.GatewayV1alpha2().TCPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.TCPRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr2)
+		assert.Equal(t, 100-desiredWeight, *(updatedTCP.Spec.Rules[0].BackendRefs[0].Weight))
+		assert.Equal(t, desiredWeight, *(updatedTCP.Spec.Rules[0].BackendRefs[1].Weight))
+		updatedTLS, getErr3 := rpcPluginImp.GatewayAPIClientset.GatewayV1alpha2().TLSRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.TLSRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr3)
+		assert.Equal(t, 100-desiredWeight, *(updatedTLS.Spec.Rules[0].BackendRefs[0].Weight))
+		assert.Equal(t, desiredWeight, *(updatedTLS.Spec.Rules[0].BackendRefs[1].Weight))
 	})
 	t.Run("SetHTTPHeaderRoute", func(t *testing.T) {
 		headerName := "X-Test"
@@ -287,10 +301,12 @@ func TestRunSuccessfully(t *testing.T) {
 		err := pluginInstance.SetHeaderRoute(rollout, &headerRouting)
 
 		assert.Empty(t, err.Error())
-		assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Name))
-		assert.Equal(t, headerName, string(rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Matches[0].Headers[0].Name))
-		assert.Equal(t, prefixedHeaderValue, rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Matches[0].Headers[0].Value)
-		assert.Equal(t, headerValueType, *rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Matches[0].Headers[0].Type)
+		updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, mocks.ManagedRouteName, string(*updatedHTTP.Spec.Rules[1].Name))
+		assert.Equal(t, headerName, string(updatedHTTP.Spec.Rules[1].Matches[0].Headers[0].Name))
+		assert.Equal(t, prefixedHeaderValue, updatedHTTP.Spec.Rules[1].Matches[0].Headers[0].Value)
+		assert.Equal(t, headerValueType, *updatedHTTP.Spec.Rules[1].Matches[0].Headers[0].Type)
 	})
 	t.Run("SetGRPCHeaderRoute", func(t *testing.T) {
 		headerName := "X-Test"
@@ -316,10 +332,12 @@ func TestRunSuccessfully(t *testing.T) {
 		err := pluginInstance.SetHeaderRoute(rollout, &headerRouting)
 
 		assert.Empty(t, err.Error())
-		assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Name))
-		assert.Equal(t, headerName, string(rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Matches[0].Headers[0].Name))
-		assert.Equal(t, prefixedHeaderValue, rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Matches[0].Headers[0].Value)
-		assert.Equal(t, headerValueType, *rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Matches[0].Headers[0].Type)
+		updatedGRPC, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, mocks.ManagedRouteName, string(*updatedGRPC.Spec.Rules[1].Name))
+		assert.Equal(t, headerName, string(updatedGRPC.Spec.Rules[1].Matches[0].Headers[0].Name))
+		assert.Equal(t, prefixedHeaderValue, updatedGRPC.Spec.Rules[1].Matches[0].Headers[0].Value)
+		assert.Equal(t, headerValueType, *updatedGRPC.Spec.Rules[1].Matches[0].Headers[0].Type)
 	})
 	t.Run("SetGRPCHeaderRouteWithFilters", func(t *testing.T) {
 		// Create a GRPCRoute mock with filters
@@ -349,8 +367,8 @@ func TestRunSuccessfully(t *testing.T) {
 			},
 		}
 
-		// Update the plugin's GRPCRouteClient with the new mock
-		rpcPluginImp.GRPCRouteClient = gwFake.NewSimpleClientset(&grpcRouteWithFilters).GatewayV1().GRPCRoutes(mocks.RolloutNamespace)
+		// Update the plugin's GatewayAPIClientset with the new mock
+		rpcPluginImp.GatewayAPIClientset = gwFake.NewSimpleClientset(&mocks.HTTPRouteObj, &grpcRouteWithFilters, &mocks.TCPPRouteObj, &mocks.TLSRouteObj)
 
 		headerName := "X-Test"
 		headerValue := "test"
@@ -373,10 +391,12 @@ func TestRunSuccessfully(t *testing.T) {
 		err := pluginInstance.SetHeaderRoute(rollout, &headerRouting)
 
 		assert.Empty(t, err.Error())
-		assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Name))
+		updatedGRPC, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, mocks.ManagedRouteName, string(*updatedGRPC.Spec.Rules[1].Name))
 		// Verify that the new header route rule (index 1) has the same filters as the original route rule (index 0)
 		originalFilters := grpcRouteWithFilters.Spec.Rules[0].Filters
-		newRouteFilters := rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Filters
+		newRouteFilters := updatedGRPC.Spec.Rules[1].Filters
 
 		assert.Equal(t, len(originalFilters), len(newRouteFilters), "New route should have same number of filters as original")
 
@@ -395,8 +415,8 @@ func TestRunSuccessfully(t *testing.T) {
 		grpcRouteWithoutFilters := mocks.GRPCRouteObj
 		grpcRouteWithoutFilters.Spec.Rules[0].Filters = nil // Explicitly set to nil
 
-		// Update the plugin's GRPCRouteClient with the mock without filters
-		rpcPluginImp.GRPCRouteClient = gwFake.NewSimpleClientset(&grpcRouteWithoutFilters).GatewayV1().GRPCRoutes(mocks.RolloutNamespace)
+		// Update the plugin's GatewayAPIClientset with the mock without filters
+		rpcPluginImp.GatewayAPIClientset = gwFake.NewSimpleClientset(&mocks.HTTPRouteObj, &grpcRouteWithoutFilters, &mocks.TCPPRouteObj, &mocks.TLSRouteObj)
 
 		headerName := "X-Test"
 		headerValue := "test"
@@ -419,10 +439,12 @@ func TestRunSuccessfully(t *testing.T) {
 		err := pluginInstance.SetHeaderRoute(rollout, &headerRouting)
 
 		assert.Empty(t, err.Error())
-		assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Name))
+		updatedGRPC, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, mocks.ManagedRouteName, string(*updatedGRPC.Spec.Rules[1].Name))
 		// Verify that the new header route rule (index 1) has no filters, same as the original route rule (index 0)
 		originalFilters := grpcRouteWithoutFilters.Spec.Rules[0].Filters
-		newRouteFilters := rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Filters
+		newRouteFilters := updatedGRPC.Spec.Rules[1].Filters
 
 		assert.Nil(t, originalFilters, "Original route should have no filters")
 		assert.Equal(t, len(originalFilters), len(newRouteFilters), "New route should have same number of filters as original (none)")
@@ -456,8 +478,8 @@ func TestRunSuccessfully(t *testing.T) {
 			},
 		}
 
-		// Update the plugin's HTTPRouteClient with the new mock
-		rpcPluginImp.HTTPRouteClient = gwFake.NewSimpleClientset(&httpRouteWithFilters).GatewayV1().HTTPRoutes(mocks.RolloutNamespace)
+		// Update the plugin's GatewayAPIClientset with the new mock
+		rpcPluginImp.GatewayAPIClientset = gwFake.NewSimpleClientset(&httpRouteWithFilters, &mocks.GRPCRouteObj, &mocks.TCPPRouteObj, &mocks.TLSRouteObj)
 
 		headerName := "X-Test"
 		headerValue := "test"
@@ -480,10 +502,12 @@ func TestRunSuccessfully(t *testing.T) {
 		err := pluginInstance.SetHeaderRoute(rollout, &headerRouting)
 
 		assert.Empty(t, err.Error())
-		assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Name))
+		updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, mocks.ManagedRouteName, string(*updatedHTTP.Spec.Rules[1].Name))
 		// Verify that the new header route rule (index 1) has the same filters as the original route rule (index 0)
 		originalFilters := httpRouteWithFilters.Spec.Rules[0].Filters
-		newRouteFilters := rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Filters
+		newRouteFilters := updatedHTTP.Spec.Rules[1].Filters
 
 		assert.Equal(t, len(originalFilters), len(newRouteFilters), "New route should have same number of filters as original")
 
@@ -502,8 +526,8 @@ func TestRunSuccessfully(t *testing.T) {
 		httpRouteWithoutFilters := mocks.HTTPRouteObj
 		httpRouteWithoutFilters.Spec.Rules[0].Filters = nil // Explicitly set to nil
 
-		// Update the plugin's HTTPRouteClient with the mock without filters
-		rpcPluginImp.HTTPRouteClient = gwFake.NewSimpleClientset(&httpRouteWithoutFilters).GatewayV1().HTTPRoutes(mocks.RolloutNamespace)
+		// Update the plugin's GatewayAPIClientset with the mock without filters
+		rpcPluginImp.GatewayAPIClientset = gwFake.NewSimpleClientset(&httpRouteWithoutFilters, &mocks.GRPCRouteObj, &mocks.TCPPRouteObj, &mocks.TLSRouteObj)
 
 		headerName := "X-Test"
 		headerValue := "test"
@@ -526,10 +550,12 @@ func TestRunSuccessfully(t *testing.T) {
 		err := pluginInstance.SetHeaderRoute(rollout, &headerRouting)
 
 		assert.Empty(t, err.Error())
-		assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Name))
+		updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, mocks.ManagedRouteName, string(*updatedHTTP.Spec.Rules[1].Name))
 		// Verify that the new header route rule (index 1) has no filters, same as the original route rule (index 0)
 		originalFilters := httpRouteWithoutFilters.Spec.Rules[0].Filters
-		newRouteFilters := rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Filters
+		newRouteFilters := updatedHTTP.Spec.Rules[1].Filters
 
 		assert.Nil(t, originalFilters, "Original route should have no filters")
 		assert.Equal(t, len(originalFilters), len(newRouteFilters), "New route should have same number of filters as original (none)")
@@ -543,7 +569,9 @@ func TestRunSuccessfully(t *testing.T) {
 		err := pluginInstance.RemoveManagedRoutes(rollout)
 
 		assert.Empty(t, err.Error())
-		assert.Equal(t, 1, len(rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules))
+		updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, 1, len(updatedHTTP.Spec.Rules))
 	})
 	t.Run("RemoveGRPCManagedRoutes", func(t *testing.T) {
 		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
@@ -553,13 +581,15 @@ func TestRunSuccessfully(t *testing.T) {
 		err := pluginInstance.RemoveManagedRoutes(rollout)
 
 		assert.Empty(t, err.Error())
-		assert.Equal(t, 1, len(rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules))
+		updatedGRPC, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, 1, len(updatedGRPC.Spec.Rules))
 	})
 	t.Run("SetWeightDoesNotClobberHTTPHeaderRouteWeight", func(t *testing.T) {
 		// Reproduces issues #158 and #169: SetWeight(0) must not touch the canary
 		// BackendRef weight in a plugin-injected header-routing rule.
 		httpRoute := mocks.HTTPRouteObj
-		rpcPluginImp.HTTPRouteClient = gwFake.NewSimpleClientset(&httpRoute).GatewayV1().HTTPRoutes(mocks.RolloutNamespace)
+		rpcPluginImp.GatewayAPIClientset = gwFake.NewSimpleClientset(&httpRoute, &mocks.GRPCRouteObj, &mocks.TCPPRouteObj, &mocks.TLSRouteObj)
 
 		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
 			Namespace: mocks.RolloutNamespace,
@@ -578,24 +608,28 @@ func TestRunSuccessfully(t *testing.T) {
 		}
 		err := pluginInstance.SetHeaderRoute(rollout, &headerRouting)
 		assert.Empty(t, err.Error())
-		assert.Equal(t, 2, len(rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules))
-		assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Name))
+		updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, 2, len(updatedHTTP.Spec.Rules))
+		assert.Equal(t, mocks.ManagedRouteName, string(*updatedHTTP.Spec.Rules[1].Name))
 
 		// Now call SetWeight(0) — the header rule's canary weight must remain nil
 		err = pluginInstance.SetWeight(rollout, 0, []v1alpha1.WeightDestination{})
 		assert.Empty(t, err.Error())
 
+		updatedHTTP, getErr = rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
 		// Weight-splitting rule (index 0): stable=100, canary=0
-		assert.Equal(t, int32(100), *rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[0].BackendRefs[0].Weight)
-		assert.Equal(t, int32(0), *rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[0].BackendRefs[1].Weight)
+		assert.Equal(t, int32(100), *updatedHTTP.Spec.Rules[0].BackendRefs[0].Weight)
+		assert.Equal(t, int32(0), *updatedHTTP.Spec.Rules[0].BackendRefs[1].Weight)
 		// Header-route rule (index 1): canary BackendRef weight must be untouched (nil)
-		assert.Nil(t, rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].BackendRefs[0].Weight)
+		assert.Nil(t, updatedHTTP.Spec.Rules[1].BackendRefs[0].Weight)
 	})
 	t.Run("SetWeightDoesNotClobberGRPCHeaderRouteWeight", func(t *testing.T) {
 		// Reproduces issues #158 and #169 for GRPCRoute: SetWeight(0) must not touch
 		// the canary BackendRef weight in a plugin-injected header-routing rule.
 		grpcRoute := mocks.GRPCRouteObj
-		rpcPluginImp.GRPCRouteClient = gwFake.NewSimpleClientset(&grpcRoute).GatewayV1().GRPCRoutes(mocks.RolloutNamespace)
+		rpcPluginImp.GatewayAPIClientset = gwFake.NewSimpleClientset(&mocks.HTTPRouteObj, &grpcRoute, &mocks.TCPPRouteObj, &mocks.TLSRouteObj)
 
 		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
 			Namespace: mocks.RolloutNamespace,
@@ -614,18 +648,22 @@ func TestRunSuccessfully(t *testing.T) {
 		}
 		err := pluginInstance.SetHeaderRoute(rollout, &headerRouting)
 		assert.Empty(t, err.Error())
-		assert.Equal(t, 2, len(rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules))
-		assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Name))
+		updatedGRPC, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
+		assert.Equal(t, 2, len(updatedGRPC.Spec.Rules))
+		assert.Equal(t, mocks.ManagedRouteName, string(*updatedGRPC.Spec.Rules[1].Name))
 
 		// Now call SetWeight(0) — the header rule's canary weight must remain nil
 		err = pluginInstance.SetWeight(rollout, 0, []v1alpha1.WeightDestination{})
 		assert.Empty(t, err.Error())
 
+		updatedGRPC, getErr = rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+		assert.NoError(t, getErr)
 		// Weight-splitting rule (index 0): stable=100, canary=0
-		assert.Equal(t, int32(100), *rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[0].BackendRefs[0].Weight)
-		assert.Equal(t, int32(0), *rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[0].BackendRefs[1].Weight)
+		assert.Equal(t, int32(100), *updatedGRPC.Spec.Rules[0].BackendRefs[0].Weight)
+		assert.Equal(t, int32(0), *updatedGRPC.Spec.Rules[0].BackendRefs[1].Weight)
 		// Header-route rule (index 1): canary BackendRef weight must be untouched (nil)
-		assert.Nil(t, rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].BackendRefs[0].Weight)
+		assert.Nil(t, updatedGRPC.Spec.Rules[1].BackendRefs[0].Weight)
 	})
 
 	// Canceling should cause an exit
@@ -896,9 +934,8 @@ func TestSetHTTPHeaderRouteWithExistingHeaders(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:          utils.SetupLog(),
-		IsTest:          true,
-		HTTPRouteClient: gwFake.NewSimpleClientset(httpRoute).GatewayV1().HTTPRoutes(mocks.RolloutNamespace),
+		LogCtx:              utils.SetupLog(),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
 	}
 
 	// Setup canary header
@@ -924,10 +961,12 @@ func TestSetHTTPHeaderRouteWithExistingHeaders(t *testing.T) {
 	// Call SetHeaderRoute
 	err := rpcPluginImp.SetHeaderRoute(rollout, &headerRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Name))
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, mocks.ManagedRouteName, string(*updatedHTTP.Spec.Rules[1].Name))
 
 	// Verify that managed route (index 1) includes BOTH original header AND canary header
-	managedRouteMatches := rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Matches
+	managedRouteMatches := updatedHTTP.Spec.Rules[1].Matches
 	assert.NotEmpty(t, managedRouteMatches, "Managed route should have matches")
 
 	// Verify headers are merged correctly
@@ -964,9 +1003,8 @@ func TestSetHTTPHeaderRouteWithExistingMethod(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:          utils.SetupLog(),
-		IsTest:          true,
-		HTTPRouteClient: gwFake.NewSimpleClientset(httpRoute).GatewayV1().HTTPRoutes(mocks.RolloutNamespace),
+		LogCtx:              utils.SetupLog(),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
 	}
 
 	// Setup canary header
@@ -992,10 +1030,12 @@ func TestSetHTTPHeaderRouteWithExistingMethod(t *testing.T) {
 	// Call SetHeaderRoute
 	err := rpcPluginImp.SetHeaderRoute(rollout, &headerRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Name))
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, mocks.ManagedRouteName, string(*updatedHTTP.Spec.Rules[1].Name))
 
 	// Verify that managed route (index 1) includes BOTH method AND canary header
-	managedRouteMatches := rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Matches
+	managedRouteMatches := updatedHTTP.Spec.Rules[1].Matches
 	assert.NotEmpty(t, managedRouteMatches, "Managed route should have matches")
 
 	// Verify method and headers are both preserved
@@ -1029,9 +1069,8 @@ func TestSetHTTPHeaderRouteWithExistingQueryParams(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:          utils.SetupLog(),
-		IsTest:          true,
-		HTTPRouteClient: gwFake.NewSimpleClientset(httpRoute).GatewayV1().HTTPRoutes(mocks.RolloutNamespace),
+		LogCtx:              utils.SetupLog(),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
 	}
 
 	// Setup canary header
@@ -1057,10 +1096,12 @@ func TestSetHTTPHeaderRouteWithExistingQueryParams(t *testing.T) {
 	// Call SetHeaderRoute
 	err := rpcPluginImp.SetHeaderRoute(rollout, &headerRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Name))
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, mocks.ManagedRouteName, string(*updatedHTTP.Spec.Rules[1].Name))
 
 	// Verify that managed route (index 1) includes BOTH query params AND canary header
-	managedRouteMatches := rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Matches
+	managedRouteMatches := updatedHTTP.Spec.Rules[1].Matches
 	assert.NotEmpty(t, managedRouteMatches, "Managed route should have matches")
 
 	// Verify query params and headers are both preserved
@@ -1101,9 +1142,8 @@ func TestSetHTTPHeaderRouteWithMultipleExistingHeaders(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:          utils.SetupLog(),
-		IsTest:          true,
-		HTTPRouteClient: gwFake.NewSimpleClientset(httpRoute).GatewayV1().HTTPRoutes(mocks.RolloutNamespace),
+		LogCtx:              utils.SetupLog(),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
 	}
 
 	// Setup canary header
@@ -1129,10 +1169,12 @@ func TestSetHTTPHeaderRouteWithMultipleExistingHeaders(t *testing.T) {
 	// Call SetHeaderRoute
 	err := rpcPluginImp.SetHeaderRoute(rollout, &headerRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Name))
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, mocks.ManagedRouteName, string(*updatedHTTP.Spec.Rules[1].Name))
 
 	// Verify that managed route (index 1) includes ALL original headers plus canary header
-	managedRouteMatches := rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Matches
+	managedRouteMatches := updatedHTTP.Spec.Rules[1].Matches
 	assert.NotEmpty(t, managedRouteMatches, "Managed route should have matches")
 
 	// Verify all headers are merged correctly
@@ -1197,9 +1239,8 @@ func TestSetHTTPHeaderRouteWithCombinedMatches(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:          utils.SetupLog(),
-		IsTest:          true,
-		HTTPRouteClient: gwFake.NewSimpleClientset(httpRoute).GatewayV1().HTTPRoutes(mocks.RolloutNamespace),
+		LogCtx:              utils.SetupLog(),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
 	}
 
 	// Setup canary header
@@ -1225,10 +1266,12 @@ func TestSetHTTPHeaderRouteWithCombinedMatches(t *testing.T) {
 	// Call SetHeaderRoute
 	err := rpcPluginImp.SetHeaderRoute(rollout, &headerRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Name))
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, mocks.ManagedRouteName, string(*updatedHTTP.Spec.Rules[1].Name))
 
 	// Verify that managed route (index 1) includes ALL original match criteria plus canary header
-	managedRouteMatches := rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Matches
+	managedRouteMatches := updatedHTTP.Spec.Rules[1].Matches
 	assert.NotEmpty(t, managedRouteMatches, "Managed route should have matches")
 
 	// Verify all match criteria are preserved
@@ -1282,9 +1325,8 @@ func TestSetGRPCHeaderRouteWithExistingHeaders(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:          utils.SetupLog(),
-		IsTest:          true,
-		GRPCRouteClient: gwFake.NewSimpleClientset(grpcRoute).GatewayV1().GRPCRoutes(mocks.RolloutNamespace),
+		LogCtx:              utils.SetupLog(),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(grpcRoute),
 	}
 
 	// Setup canary header
@@ -1310,10 +1352,12 @@ func TestSetGRPCHeaderRouteWithExistingHeaders(t *testing.T) {
 	// Call SetHeaderRoute
 	err := rpcPluginImp.SetHeaderRoute(rollout, &headerRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Name))
+	updatedGRPC, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, mocks.ManagedRouteName, string(*updatedGRPC.Spec.Rules[1].Name))
 
 	// Verify that managed route (index 1) includes BOTH original header AND canary header
-	managedRouteMatches := rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Matches
+	managedRouteMatches := updatedGRPC.Spec.Rules[1].Matches
 	assert.NotEmpty(t, managedRouteMatches, "Managed route should have matches")
 
 	// Verify headers are merged correctly
@@ -1363,9 +1407,8 @@ func TestSetGRPCHeaderRouteWithMultipleExistingHeaders(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:          utils.SetupLog(),
-		IsTest:          true,
-		GRPCRouteClient: gwFake.NewSimpleClientset(grpcRoute).GatewayV1().GRPCRoutes(mocks.RolloutNamespace),
+		LogCtx:              utils.SetupLog(),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(grpcRoute),
 	}
 
 	// Setup canary header
@@ -1391,10 +1434,12 @@ func TestSetGRPCHeaderRouteWithMultipleExistingHeaders(t *testing.T) {
 	// Call SetHeaderRoute
 	err := rpcPluginImp.SetHeaderRoute(rollout, &headerRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Name))
+	updatedGRPC, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, mocks.ManagedRouteName, string(*updatedGRPC.Spec.Rules[1].Name))
 
 	// Verify that managed route (index 1) includes ALL original headers plus canary header
-	managedRouteMatches := rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Matches
+	managedRouteMatches := updatedGRPC.Spec.Rules[1].Matches
 	assert.NotEmpty(t, managedRouteMatches, "Managed route should have matches")
 
 	// Verify all headers are merged correctly
@@ -1451,9 +1496,8 @@ func TestSetGRPCHeaderRouteWithMethodAndHeaders(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:          utils.SetupLog(),
-		IsTest:          true,
-		GRPCRouteClient: gwFake.NewSimpleClientset(grpcRoute).GatewayV1().GRPCRoutes(mocks.RolloutNamespace),
+		LogCtx:              utils.SetupLog(),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(grpcRoute),
 	}
 
 	// Setup canary header
@@ -1479,10 +1523,12 @@ func TestSetGRPCHeaderRouteWithMethodAndHeaders(t *testing.T) {
 	// Call SetHeaderRoute
 	err := rpcPluginImp.SetHeaderRoute(rollout, &headerRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Name))
+	updatedGRPC, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, mocks.ManagedRouteName, string(*updatedGRPC.Spec.Rules[1].Name))
 
 	// Verify that managed route (index 1) includes method AND all headers (original + canary)
-	managedRouteMatches := rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Matches
+	managedRouteMatches := updatedGRPC.Spec.Rules[1].Matches
 	assert.NotEmpty(t, managedRouteMatches, "Managed route should have matches")
 
 	// Verify method and headers are both preserved
@@ -1532,9 +1578,8 @@ func TestSetHTTPHeaderRouteNoDuplicateOnRepeatedCall(t *testing.T) {
 	httpRoute := mocks.CreateHTTPRouteWithLabels(mocks.HTTPRouteName, nil)
 
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:          utils.SetupLog(),
-		IsTest:          true,
-		HTTPRouteClient: gwFake.NewSimpleClientset(httpRoute).GatewayV1().HTTPRoutes(mocks.RolloutNamespace),
+		LogCtx:              utils.SetupLog(),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
 	}
 
 	headerMatch := v1alpha1.StringMatch{Exact: "true"}
@@ -1555,17 +1600,18 @@ func TestSetHTTPHeaderRouteNoDuplicateOnRepeatedCall(t *testing.T) {
 	// First call — should add one managed rule (total: 2 rules)
 	err := rpcPluginImp.SetHeaderRoute(rollout, &headerRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, 2, len(rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules), "first call should add exactly one managed rule")
-	assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Name))
-
-	// Simulate the state the fake client has after the first update
-	rpcPluginImp.HTTPRouteClient = gwFake.NewSimpleClientset(rpcPluginImp.UpdatedHTTPRouteMock).GatewayV1().HTTPRoutes(mocks.RolloutNamespace)
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, 2, len(updatedHTTP.Spec.Rules), "first call should add exactly one managed rule")
+	assert.Equal(t, mocks.ManagedRouteName, string(*updatedHTTP.Spec.Rules[1].Name))
 
 	// Second call with the same header route name — should update in place, not append
 	err = rpcPluginImp.SetHeaderRoute(rollout, &headerRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, 2, len(rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules), "second call must not add a duplicate managed rule")
-	assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Name))
+	updatedHTTP, getErr = rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, 2, len(updatedHTTP.Spec.Rules), "second call must not add a duplicate managed rule")
+	assert.Equal(t, mocks.ManagedRouteName, string(*updatedHTTP.Spec.Rules[1].Name))
 }
 
 // TestSetGRPCHeaderRouteNoDuplicateOnRepeatedCall verifies that calling SetHeaderRoute multiple
@@ -1574,9 +1620,8 @@ func TestSetGRPCHeaderRouteNoDuplicateOnRepeatedCall(t *testing.T) {
 	grpcRoute := mocks.CreateGRPCRouteWithLabels(mocks.GRPCRouteName, nil)
 
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:          utils.SetupLog(),
-		IsTest:          true,
-		GRPCRouteClient: gwFake.NewSimpleClientset(grpcRoute).GatewayV1().GRPCRoutes(mocks.RolloutNamespace),
+		LogCtx:              utils.SetupLog(),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(grpcRoute),
 	}
 
 	headerMatch := v1alpha1.StringMatch{Exact: "true"}
@@ -1597,17 +1642,18 @@ func TestSetGRPCHeaderRouteNoDuplicateOnRepeatedCall(t *testing.T) {
 	// First call — should add one managed rule (total: 2 rules)
 	err := rpcPluginImp.SetHeaderRoute(rollout, &headerRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, 2, len(rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules), "first call should add exactly one managed rule")
-	assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Name))
-
-	// Simulate the state the fake client has after the first update
-	rpcPluginImp.GRPCRouteClient = gwFake.NewSimpleClientset(rpcPluginImp.UpdatedGRPCRouteMock).GatewayV1().GRPCRoutes(mocks.RolloutNamespace)
+	updatedGRPC, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, 2, len(updatedGRPC.Spec.Rules), "first call should add exactly one managed rule")
+	assert.Equal(t, mocks.ManagedRouteName, string(*updatedGRPC.Spec.Rules[1].Name))
 
 	// Second call with the same header route name — should update in place, not append
 	err = rpcPluginImp.SetHeaderRoute(rollout, &headerRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, 2, len(rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules), "second call must not add a duplicate managed rule")
-	assert.Equal(t, mocks.ManagedRouteName, string(*rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Name))
+	updatedGRPC, getErr = rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, 2, len(updatedGRPC.Spec.Rules), "second call must not add a duplicate managed rule")
+	assert.Equal(t, mocks.ManagedRouteName, string(*updatedGRPC.Spec.Rules[1].Name))
 }
 
 // TestSetHTTPHeaderRouteTwoDistinctNamesAppendsBoth verifies that adding two managed header
@@ -1616,9 +1662,8 @@ func TestSetHTTPHeaderRouteTwoDistinctNamesAppendsBoth(t *testing.T) {
 	httpRoute := mocks.CreateHTTPRouteWithLabels(mocks.HTTPRouteName, nil)
 
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:          utils.SetupLog(),
-		IsTest:          true,
-		HTTPRouteClient: gwFake.NewSimpleClientset(httpRoute).GatewayV1().HTTPRoutes(mocks.RolloutNamespace),
+		LogCtx:              utils.SetupLog(),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
 	}
 
 	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
@@ -1645,18 +1690,19 @@ func TestSetHTTPHeaderRouteTwoDistinctNamesAppendsBoth(t *testing.T) {
 	// Add the first managed route
 	err := rpcPluginImp.SetHeaderRoute(rollout, &firstHeaderRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, 2, len(rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules), "first call should add one managed rule")
-	assert.Equal(t, "header-route-one", string(*rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Name))
-
-	// Reflect the updated route in the fake client before the second call
-	rpcPluginImp.HTTPRouteClient = gwFake.NewSimpleClientset(rpcPluginImp.UpdatedHTTPRouteMock).GatewayV1().HTTPRoutes(mocks.RolloutNamespace)
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, 2, len(updatedHTTP.Spec.Rules), "first call should add one managed rule")
+	assert.Equal(t, "header-route-one", string(*updatedHTTP.Spec.Rules[1].Name))
 
 	// Add a second managed route with a different name — must be appended, not replace the first
 	err = rpcPluginImp.SetHeaderRoute(rollout, &secondHeaderRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, 3, len(rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules), "second distinct header route must be appended")
-	assert.Equal(t, "header-route-one", string(*rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[1].Name))
-	assert.Equal(t, "header-route-two", string(*rpcPluginImp.UpdatedHTTPRouteMock.Spec.Rules[2].Name))
+	updatedHTTP, getErr = rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, 3, len(updatedHTTP.Spec.Rules), "second distinct header route must be appended")
+	assert.Equal(t, "header-route-one", string(*updatedHTTP.Spec.Rules[1].Name))
+	assert.Equal(t, "header-route-two", string(*updatedHTTP.Spec.Rules[2].Name))
 }
 
 // TestSetGRPCHeaderRouteTwoDistinctNamesAppendsBoth verifies that adding two managed header
@@ -1665,9 +1711,8 @@ func TestSetGRPCHeaderRouteTwoDistinctNamesAppendsBoth(t *testing.T) {
 	grpcRoute := mocks.CreateGRPCRouteWithLabels(mocks.GRPCRouteName, nil)
 
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:          utils.SetupLog(),
-		IsTest:          true,
-		GRPCRouteClient: gwFake.NewSimpleClientset(grpcRoute).GatewayV1().GRPCRoutes(mocks.RolloutNamespace),
+		LogCtx:              utils.SetupLog(),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(grpcRoute),
 	}
 
 	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
@@ -1694,18 +1739,19 @@ func TestSetGRPCHeaderRouteTwoDistinctNamesAppendsBoth(t *testing.T) {
 	// Add the first managed route
 	err := rpcPluginImp.SetHeaderRoute(rollout, &firstHeaderRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, 2, len(rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules), "first call should add one managed rule")
-	assert.Equal(t, "header-route-one", string(*rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Name))
-
-	// Reflect the updated route in the fake client before the second call
-	rpcPluginImp.GRPCRouteClient = gwFake.NewSimpleClientset(rpcPluginImp.UpdatedGRPCRouteMock).GatewayV1().GRPCRoutes(mocks.RolloutNamespace)
+	updatedGRPC, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, 2, len(updatedGRPC.Spec.Rules), "first call should add one managed rule")
+	assert.Equal(t, "header-route-one", string(*updatedGRPC.Spec.Rules[1].Name))
 
 	// Add a second managed route with a different name — must be appended, not replace the first
 	err = rpcPluginImp.SetHeaderRoute(rollout, &secondHeaderRouting)
 	assert.Empty(t, err.Error())
-	assert.Equal(t, 3, len(rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules), "second distinct header route must be appended")
-	assert.Equal(t, "header-route-one", string(*rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[1].Name))
-	assert.Equal(t, "header-route-two", string(*rpcPluginImp.UpdatedGRPCRouteMock.Spec.Rules[2].Name))
+	updatedGRPC, getErr = rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+	assert.NoError(t, getErr)
+	assert.Equal(t, 3, len(updatedGRPC.Spec.Rules), "second distinct header route must be appended")
+	assert.Equal(t, "header-route-one", string(*updatedGRPC.Spec.Rules[1].Name))
+	assert.Equal(t, "header-route-two", string(*updatedGRPC.Spec.Rules[2].Name))
 }
 
 // TestGetRouteRuleOnlyReturnsRuleWithAllBackends verifies that getRouteRule only returns

--- a/pkg/plugin/tcproute.go
+++ b/pkg/plugin/tcproute.go
@@ -8,22 +8,16 @@ import (
 	pluginTypes "github.com/argoproj/argo-rollouts/utils/plugin/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func (r *RpcPlugin) setTCPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight int32, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
 	ctx := context.TODO()
-	tcpRouteClient := r.TCPRouteClient
-	if !r.IsTest {
-		gatewayClientV1alpha2 := r.GatewayAPIClientset.GatewayV1alpha2()
-		tcpRouteClient = gatewayClientV1alpha2.TCPRoutes(gatewayAPIConfig.Namespace)
-	}
+	tcpRouteClient := r.GatewayAPIClientset.GatewayV1alpha2().TCPRoutes(gatewayAPIConfig.Namespace)
 
 	canaryServiceName := rollout.Spec.Strategy.Canary.CanaryService
 	stableServiceName := rollout.Spec.Strategy.Canary.StableService
 	restWeight := 100 - desiredWeight
 
-	var updatedTCPRoute *v1alpha2.TCPRoute
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		tcpRoute, err := tcpRouteClient.Get(ctx, gatewayAPIConfig.TCPRoute, metav1.GetOptions{})
 		if err != nil {
@@ -48,13 +42,10 @@ func (r *RpcPlugin) setTCPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight i
 
 		ensureInProgressLabel(tcpRoute, desiredWeight, gatewayAPIConfig)
 
-		updatedTCPRoute, err = tcpRouteClient.Update(ctx, tcpRoute, metav1.UpdateOptions{})
+		_, err = tcpRouteClient.Update(ctx, tcpRoute, metav1.UpdateOptions{})
 		return err
 	})
 
-	if r.IsTest {
-		r.UpdatedTCPRouteMock = updatedTCPRoute
-	}
 	if err != nil {
 		return pluginTypes.RpcError{
 			ErrorString: err.Error(),

--- a/pkg/plugin/tlsroute.go
+++ b/pkg/plugin/tlsroute.go
@@ -8,22 +8,16 @@ import (
 	pluginTypes "github.com/argoproj/argo-rollouts/utils/plugin/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
-	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func (r *RpcPlugin) setTLSRouteWeight(rollout *v1alpha1.Rollout, desiredWeight int32, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
 	ctx := context.TODO()
-	tlsRouteClient := r.TLSRouteClient
-	if !r.IsTest {
-		gatewayClientV1alpha2 := r.GatewayAPIClientset.GatewayV1alpha2()
-		tlsRouteClient = gatewayClientV1alpha2.TLSRoutes(gatewayAPIConfig.Namespace)
-	}
+	tlsRouteClient := r.GatewayAPIClientset.GatewayV1alpha2().TLSRoutes(gatewayAPIConfig.Namespace)
 
 	canaryServiceName := rollout.Spec.Strategy.Canary.CanaryService
 	stableServiceName := rollout.Spec.Strategy.Canary.StableService
 	restWeight := 100 - desiredWeight
 
-	var updatedTLSRoute *v1alpha2.TLSRoute
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		tlsRoute, err := tlsRouteClient.Get(ctx, gatewayAPIConfig.TLSRoute, metav1.GetOptions{})
 		if err != nil {
@@ -48,13 +42,10 @@ func (r *RpcPlugin) setTLSRouteWeight(rollout *v1alpha1.Rollout, desiredWeight i
 
 		ensureInProgressLabel(tlsRoute, desiredWeight, gatewayAPIConfig)
 
-		updatedTLSRoute, err = tlsRouteClient.Update(ctx, tlsRoute, metav1.UpdateOptions{})
+		_, err = tlsRouteClient.Update(ctx, tlsRoute, metav1.UpdateOptions{})
 		return err
 	})
 
-	if r.IsTest {
-		r.UpdatedTLSRouteMock = updatedTLSRoute
-	}
 	if err != nil {
 		return pluginTypes.RpcError{
 			ErrorString: err.Error(),

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -7,8 +7,6 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayAPIClientset "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
-	gatewayApiClientv1 "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1"
-	gatewayApiClientv1alpha2 "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1alpha2"
 )
 
 type CommandLineOpts struct {
@@ -17,19 +15,10 @@ type CommandLineOpts struct {
 }
 
 type RpcPlugin struct {
-	CommandLineOpts      CommandLineOpts
-	HTTPRouteClient      gatewayApiClientv1.HTTPRouteInterface
-	TCPRouteClient       gatewayApiClientv1alpha2.TCPRouteInterface
-	GRPCRouteClient      gatewayApiClientv1.GRPCRouteInterface
-	TLSRouteClient       gatewayApiClientv1alpha2.TLSRouteInterface
-	GatewayAPIClientset  *gatewayAPIClientset.Clientset
-	Clientset            *kubernetes.Clientset
-	UpdatedHTTPRouteMock *gatewayv1.HTTPRoute
-	UpdatedTCPRouteMock  *v1alpha2.TCPRoute
-	UpdatedGRPCRouteMock *gatewayv1.GRPCRoute
-	UpdatedTLSRouteMock  *v1alpha2.TLSRoute
-	LogCtx               *logrus.Entry
-	IsTest               bool
+	CommandLineOpts     CommandLineOpts
+	GatewayAPIClientset gatewayAPIClientset.Interface
+	Clientset           *kubernetes.Clientset
+	LogCtx              *logrus.Entry
 }
 
 type GatewayAPITrafficRouting struct {


### PR DESCRIPTION
## Description of this PR

Remove all code that is used in unit tests from production code. Described in https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/issues/185

## Checklist:

* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] My build is green.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged
* [x] The tests actually define testcases about the feature/fix implemented
* [x] I have run all tests locally and they pass
* [x] I haven't changed the existing tests in a significant way, as this will break functionality for existing users <sup>1</sup>
* [x] I've updated documentation as required by this PR.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY it works that way according to my use case
* [x] I understand what the code does and HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My new code is using existing utility functions instead of re-implementing everything again
* [x] Optional. My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md)

Notes

1. Unless a discussion has happened already in an issue and the breaking change is deemed acceptable
