### PR TITLE
fix: Do not tamper with unmanaged backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 dist
 .idea
+coverage.out
+coverage.html

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,11 @@ lint:
 unit-tests:
 	go test -v -count=1 ./pkg/...
 
+.PHONY: coverage
+coverage:
+	go test -v -count=1 -coverprofile=coverage.out -covermode=atomic ./pkg/...
+	go tool cover -html=coverage.out -o coverage.html
+
 .PHONY: setup-e2e-cluster
 setup-e2e-cluster:
 	make BIN_NAME=gatewayapi-plugin-linux-amd64 GOOS=linux GOARCH=amd64 gatewayapi-plugin-build

--- a/pkg/plugin/experiment.go
+++ b/pkg/plugin/experiment.go
@@ -35,10 +35,20 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 
 	isExperimentActive := rollout.Spec.Strategy.Canary != nil && rollout.Status.Canary.CurrentExperiment != ""
 
+	// previousServices are the experiment services the controller told the plugin to add
+	// on the previous reconcile, recorded in the rollout status. These are the only
+	// backends the plugin owns and may remove; any other backend in the route is managed
+	// externally and must be left untouched (issue #203).
+	previousServices := make(map[string]bool)
+	if rollout.Status.Canary.Weights != nil {
+		for _, dest := range rollout.Status.Canary.Weights.Additional {
+			previousServices[dest.ServiceName] = true
+		}
+	}
+
 	hasExperimentServices := false
 	for _, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
-		serviceName := string(backendRef.Name)
-		if serviceName != stableService && serviceName != canaryService {
+		if previousServices[string(backendRef.Name)] {
 			hasExperimentServices = true
 			break
 		}
@@ -132,17 +142,19 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 		for _, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
 			serviceName := string(backendRef.Name)
 
+			if previousServices[serviceName] {
+				logger.Info(fmt.Sprintf("Removing experiment service from HTTPRoute: %s", serviceName))
+				continue
+			}
+
 			switch serviceName {
 			case stableService:
 				backendRef.Weight = &stableWeight
-				filteredBackendRefs = append(filteredBackendRefs, backendRef)
 			case canaryService:
 				zeroWeight := int32(0)
 				backendRef.Weight = &zeroWeight
-				filteredBackendRefs = append(filteredBackendRefs, backendRef)
-			default:
-				logger.Info(fmt.Sprintf("Removing experiment service from HTTPRoute: %s", serviceName))
 			}
+			filteredBackendRefs = append(filteredBackendRefs, backendRef)
 		}
 
 		httpRoute.Spec.Rules[ruleIdx].BackendRefs = filteredBackendRefs

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -1854,6 +1854,88 @@ func TestGetRouteRuleOnlyReturnsRuleWithAllBackends(t *testing.T) {
 	assert.True(t, foundCanary, "Should have canary backend")
 }
 
+// TestSetWeightPreservesUnmanagedHTTPBackends verifies that SetWeight does not strip
+// HTTPRoute backends that are not managed by the plugin (issue #203). An HTTPRoute
+// with extra backends beyond stable and canary must retain all backends at every
+// weight step — during the canary and after it completes.
+func TestSetWeightPreservesUnmanagedHTTPBackends(t *testing.T) {
+	const extraServiceName = "extra-pipeline-service"
+	stableWeight := int32(100)
+	canaryWeight := int32(0)
+	extraWeight := int32(1)
+	port := gatewayv1.PortNumber(80)
+
+	httpRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mocks.HTTPRouteName,
+			Namespace: mocks.RolloutNamespace,
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: mocks.StableServiceName,
+									Port: &port,
+								},
+								Weight: &stableWeight,
+							},
+						},
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: mocks.CanaryServiceName,
+									Port: &port,
+								},
+								Weight: &canaryWeight,
+							},
+						},
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: extraServiceName,
+									Port: &port,
+								},
+								Weight: &extraWeight,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog(),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute, &mocks.GRPCRouteObj, &mocks.TCPPRouteObj, &mocks.TLSRouteObj),
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+		Namespace: mocks.RolloutNamespace,
+		HTTPRoute: mocks.HTTPRouteName,
+	})
+
+	rpcErr := rpcPluginImp.SetWeight(rollout, 30, []v1alpha1.WeightDestination{})
+	assert.Empty(t, rpcErr.Error())
+
+	updated, err := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, updated.Spec.Rules[0].BackendRefs, 3, "extra backend must not be stripped during canary")
+	assert.Equal(t, int32(70), *updated.Spec.Rules[0].BackendRefs[0].Weight)
+	assert.Equal(t, int32(30), *updated.Spec.Rules[0].BackendRefs[1].Weight)
+	assert.Equal(t, gatewayv1.ObjectName(extraServiceName), updated.Spec.Rules[0].BackendRefs[2].Name)
+
+	rpcErr = rpcPluginImp.SetWeight(rollout, 0, []v1alpha1.WeightDestination{})
+	assert.Empty(t, rpcErr.Error())
+
+	updated, err = rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, updated.Spec.Rules[0].BackendRefs, 3, "extra backend must not be stripped after rollout completes")
+	assert.Equal(t, int32(0), *updated.Spec.Rules[0].BackendRefs[1].Weight)
+	assert.Equal(t, gatewayv1.ObjectName(extraServiceName), updated.Spec.Rules[0].BackendRefs[2].Name)
+}
+
 // TestGetRouteRuleReturnsErrorWhenBackendNotFound verifies that getRouteRule returns
 // an error when no rule contains all requested backends.
 func TestGetRouteRuleReturnsErrorWhenBackendNotFound(t *testing.T) {

--- a/test/e2e/chainsaw/httproute-extra-backends/assertions/httproute-after-cleanup.yaml
+++ b/test/e2e/chainsaw/httproute-extra-backends/assertions/httproute-after-cleanup.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-extra-backends
+  namespace: default
+spec:
+  (length(rules)): 1
+  rules:
+    - (length(backendRefs)): 3
+      backendRefs:
+        - name: httproute-extra-backends-stable-service
+        - name: httproute-extra-backends-canary-service
+          (weight): 0
+        - name: httproute-extra-backends-extra-service

--- a/test/e2e/chainsaw/httproute-extra-backends/assertions/httproute-canary.yaml
+++ b/test/e2e/chainsaw/httproute-extra-backends/assertions/httproute-canary.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-extra-backends
+  namespace: default
+spec:
+  (length(rules)): 1
+  rules:
+    - (length(backendRefs)): 3
+      backendRefs:
+        - name: httproute-extra-backends-stable-service
+          (weight): 70
+        - name: httproute-extra-backends-canary-service
+          (weight): 30
+        - name: httproute-extra-backends-extra-service

--- a/test/e2e/chainsaw/httproute-extra-backends/assertions/httproute-initial.yaml
+++ b/test/e2e/chainsaw/httproute-extra-backends/assertions/httproute-initial.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-extra-backends
+  namespace: default
+spec:
+  (length(rules)): 1
+  rules:
+    - (length(backendRefs)): 3
+      backendRefs:
+        - name: httproute-extra-backends-stable-service
+        - name: httproute-extra-backends-canary-service
+          (weight): 0
+        - name: httproute-extra-backends-extra-service

--- a/test/e2e/chainsaw/httproute-extra-backends/assertions/rollout-healthy.yaml
+++ b/test/e2e/chainsaw/httproute-extra-backends/assertions/rollout-healthy.yaml
@@ -1,0 +1,7 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: httproute-extra-backends-rollout
+  namespace: default
+status:
+  (phase == 'Healthy'): true

--- a/test/e2e/chainsaw/httproute-extra-backends/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/httproute-extra-backends/chainsaw-test.yaml
@@ -1,0 +1,78 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: httproute-extra-backends
+  labels:
+    route-type: http
+spec:
+  description: >
+    Verifies that the plugin does not strip unmanaged backends from an HTTPRoute
+    during a canary rollout (issue #203). The HTTPRoute has 3 backends: stable,
+    canary (both managed by the rollout), and an extra backend managed by a
+    separate system. All 3 backends must remain present throughout the entire
+    canary lifecycle — initial state, active canary, and post-rollout cleanup.
+  namespace: default
+  concurrent: true
+
+  steps:
+    - name: create-resources
+      description: Create an HTTPRoute with 3 backends and a Rollout that manages only stable+canary.
+      try:
+        - apply:
+            file: resources/services.yaml
+        - apply:
+            file: resources/httproute.yaml
+        - apply:
+            file: resources/rollout.yaml
+
+    - name: assert-initial-state
+      description: Plugin sets canary weight to 0; the unmanaged extra backend must still be present.
+      try:
+        - assert:
+            timeout: 30s
+            file: assertions/httproute-initial.yaml
+
+    - name: wait-for-initial-healthy
+      description: Wait for the initial rollout to reach Healthy before triggering a canary.
+      try:
+        - assert:
+            timeout: 5m
+            file: assertions/rollout-healthy.yaml
+
+    - name: trigger-canary
+      description: Update the rollout image to start a canary (setWeight:30 -> pause:30s).
+      try:
+        - patch:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Rollout
+              metadata:
+                name: httproute-extra-backends-rollout
+                namespace: default
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: rollouts-demo
+                        image: argoproj/rollouts-demo:green
+
+    - name: assert-canary-weight-active
+      description: Plugin sets canary=30 stable=70; the unmanaged extra backend must still be present.
+      try:
+        - assert:
+            timeout: 2m
+            file: assertions/httproute-canary.yaml
+
+    - name: assert-rollout-healthy
+      description: Wait for the canary to complete (30s pause auto-expires).
+      try:
+        - assert:
+            timeout: 5m
+            file: assertions/rollout-healthy.yaml
+
+    - name: assert-cleanup
+      description: Plugin resets canary weight to 0; the unmanaged extra backend must still be present.
+      try:
+        - assert:
+            timeout: 60s
+            file: assertions/httproute-after-cleanup.yaml

--- a/test/e2e/chainsaw/httproute-extra-backends/resources/httproute.yaml
+++ b/test/e2e/chainsaw/httproute-extra-backends/resources/httproute.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-extra-backends
+  namespace: default
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      namespace: default
+  rules:
+    - backendRefs:
+        - name: httproute-extra-backends-stable-service
+          port: 80
+        - name: httproute-extra-backends-canary-service
+          port: 80
+        - name: httproute-extra-backends-extra-service
+          port: 80

--- a/test/e2e/chainsaw/httproute-extra-backends/resources/rollout.yaml
+++ b/test/e2e/chainsaw/httproute-extra-backends/resources/rollout.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: httproute-extra-backends-rollout
+  namespace: default
+spec:
+  replicas: 2
+  strategy:
+    canary:
+      canaryService: httproute-extra-backends-canary-service
+      stableService: httproute-extra-backends-stable-service
+      trafficRouting:
+        plugins:
+          argoproj-labs/gatewayAPI:
+            httpRoute: httproute-extra-backends
+            namespace: default
+      steps:
+        - setWeight: 30
+        - pause: {duration: 30s}
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: httproute-extra-backends
+  template:
+    metadata:
+      labels:
+        app: httproute-extra-backends
+    spec:
+      containers:
+        - name: rollouts-demo
+          image: argoproj/rollouts-demo:red
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP

--- a/test/e2e/chainsaw/httproute-extra-backends/resources/services.yaml
+++ b/test/e2e/chainsaw/httproute-extra-backends/resources/services.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: httproute-extra-backends-stable-service
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: httproute-extra-backends
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httproute-extra-backends-canary-service
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: httproute-extra-backends
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httproute-extra-backends-extra-service
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: httproute-extra-backends-extra

--- a/test/e2e/chainsaw/httproute-multiple-extra-backends/assertions/httproute-after-cleanup.yaml
+++ b/test/e2e/chainsaw/httproute-multiple-extra-backends/assertions/httproute-after-cleanup.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-multiple-extra-backends
+  namespace: default
+spec:
+  (length(rules)): 1
+  rules:
+    - (length(backendRefs)): 4
+      backendRefs:
+        - name: httproute-multiple-extra-backends-stable-service
+        - name: httproute-multiple-extra-backends-canary-service
+          (weight): 0
+        - name: httproute-multiple-extra-backends-extra-service-1
+        - name: httproute-multiple-extra-backends-extra-service-2

--- a/test/e2e/chainsaw/httproute-multiple-extra-backends/assertions/httproute-canary-20.yaml
+++ b/test/e2e/chainsaw/httproute-multiple-extra-backends/assertions/httproute-canary-20.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-multiple-extra-backends
+  namespace: default
+spec:
+  (length(rules)): 1
+  rules:
+    - (length(backendRefs)): 4
+      backendRefs:
+        - name: httproute-multiple-extra-backends-stable-service
+          (weight): 80
+        - name: httproute-multiple-extra-backends-canary-service
+          (weight): 20
+        - name: httproute-multiple-extra-backends-extra-service-1
+        - name: httproute-multiple-extra-backends-extra-service-2

--- a/test/e2e/chainsaw/httproute-multiple-extra-backends/assertions/httproute-canary-50.yaml
+++ b/test/e2e/chainsaw/httproute-multiple-extra-backends/assertions/httproute-canary-50.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-multiple-extra-backends
+  namespace: default
+spec:
+  (length(rules)): 1
+  rules:
+    - (length(backendRefs)): 4
+      backendRefs:
+        - name: httproute-multiple-extra-backends-stable-service
+          (weight): 50
+        - name: httproute-multiple-extra-backends-canary-service
+          (weight): 50
+        - name: httproute-multiple-extra-backends-extra-service-1
+        - name: httproute-multiple-extra-backends-extra-service-2

--- a/test/e2e/chainsaw/httproute-multiple-extra-backends/assertions/httproute-initial.yaml
+++ b/test/e2e/chainsaw/httproute-multiple-extra-backends/assertions/httproute-initial.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-multiple-extra-backends
+  namespace: default
+spec:
+  (length(rules)): 1
+  rules:
+    - (length(backendRefs)): 4
+      backendRefs:
+        - name: httproute-multiple-extra-backends-stable-service
+        - name: httproute-multiple-extra-backends-canary-service
+          (weight): 0
+        - name: httproute-multiple-extra-backends-extra-service-1
+        - name: httproute-multiple-extra-backends-extra-service-2

--- a/test/e2e/chainsaw/httproute-multiple-extra-backends/assertions/rollout-healthy.yaml
+++ b/test/e2e/chainsaw/httproute-multiple-extra-backends/assertions/rollout-healthy.yaml
@@ -1,0 +1,7 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: httproute-multiple-extra-backends-rollout
+  namespace: default
+status:
+  (phase == 'Healthy'): true

--- a/test/e2e/chainsaw/httproute-multiple-extra-backends/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/httproute-multiple-extra-backends/chainsaw-test.yaml
@@ -1,0 +1,86 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: httproute-multiple-extra-backends
+  labels:
+    route-type: http
+spec:
+  description: >
+    Verifies that the plugin does not strip unmanaged backends from an HTTPRoute
+    when using the httpRoutes (plural) config syntax (issue #203). The HTTPRoute
+    has 4 backends: stable and canary (managed by the rollout) plus two extra
+    backends managed by separate deployment pipelines. All 4 backends must remain
+    present at every stage of the canary rollout. Mirrors the exact configuration
+    reported in the issue.
+  namespace: default
+  concurrent: true
+
+  steps:
+    - name: create-resources
+      description: Create an HTTPRoute with 4 backends and a Rollout using httpRoutes plural syntax.
+      try:
+        - apply:
+            file: resources/services.yaml
+        - apply:
+            file: resources/httproute.yaml
+        - apply:
+            file: resources/rollout.yaml
+
+    - name: assert-initial-state
+      description: Plugin sets canary weight to 0; both unmanaged extra backends must still be present.
+      try:
+        - assert:
+            timeout: 30s
+            file: assertions/httproute-initial.yaml
+
+    - name: wait-for-initial-healthy
+      description: Wait for the initial rollout to reach Healthy before triggering a canary.
+      try:
+        - assert:
+            timeout: 5m
+            file: assertions/rollout-healthy.yaml
+
+    - name: trigger-canary
+      description: Update the rollout image to start a canary (setWeight:20 -> pause:30s -> setWeight:50 -> pause:30s).
+      try:
+        - patch:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Rollout
+              metadata:
+                name: httproute-multiple-extra-backends-rollout
+                namespace: default
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: rollouts-demo
+                        image: argoproj/rollouts-demo:green
+
+    - name: assert-canary-weight-20
+      description: Plugin sets canary=20 stable=80; both extra backends must still be present.
+      try:
+        - assert:
+            timeout: 2m
+            file: assertions/httproute-canary-20.yaml
+
+    - name: assert-canary-weight-50
+      description: Plugin sets canary=50 stable=50; both extra backends must still be present.
+      try:
+        - assert:
+            timeout: 2m
+            file: assertions/httproute-canary-50.yaml
+
+    - name: assert-rollout-healthy
+      description: Wait for the canary to complete (two 30s pauses auto-expire).
+      try:
+        - assert:
+            timeout: 5m
+            file: assertions/rollout-healthy.yaml
+
+    - name: assert-cleanup
+      description: Plugin resets canary weight to 0; both extra backends must still be present.
+      try:
+        - assert:
+            timeout: 60s
+            file: assertions/httproute-after-cleanup.yaml

--- a/test/e2e/chainsaw/httproute-multiple-extra-backends/resources/httproute.yaml
+++ b/test/e2e/chainsaw/httproute-multiple-extra-backends/resources/httproute.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-multiple-extra-backends
+  namespace: default
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      namespace: default
+  rules:
+    - backendRefs:
+        - name: httproute-multiple-extra-backends-stable-service
+          port: 80
+          weight: 100
+        - name: httproute-multiple-extra-backends-canary-service
+          port: 80
+          weight: 0
+        - name: httproute-multiple-extra-backends-extra-service-1
+          port: 80
+          weight: 1
+        - name: httproute-multiple-extra-backends-extra-service-2
+          port: 80
+          weight: 0

--- a/test/e2e/chainsaw/httproute-multiple-extra-backends/resources/rollout.yaml
+++ b/test/e2e/chainsaw/httproute-multiple-extra-backends/resources/rollout.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: httproute-multiple-extra-backends-rollout
+  namespace: default
+spec:
+  replicas: 2
+  strategy:
+    canary:
+      canaryService: httproute-multiple-extra-backends-canary-service
+      stableService: httproute-multiple-extra-backends-stable-service
+      trafficRouting:
+        plugins:
+          argoproj-labs/gatewayAPI:
+            namespace: default
+            httpRoutes:
+              - name: httproute-multiple-extra-backends
+      steps:
+        - setWeight: 20
+        - pause: {duration: 30s}
+        - setWeight: 50
+        - pause: {duration: 30s}
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: httproute-multiple-extra-backends
+  template:
+    metadata:
+      labels:
+        app: httproute-multiple-extra-backends
+    spec:
+      containers:
+        - name: rollouts-demo
+          image: argoproj/rollouts-demo:red
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP

--- a/test/e2e/chainsaw/httproute-multiple-extra-backends/resources/services.yaml
+++ b/test/e2e/chainsaw/httproute-multiple-extra-backends/resources/services.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: httproute-multiple-extra-backends-stable-service
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: httproute-multiple-extra-backends
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httproute-multiple-extra-backends-canary-service
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: httproute-multiple-extra-backends
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httproute-multiple-extra-backends-extra-service-1
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: httproute-multiple-extra-backends-extra-1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httproute-multiple-extra-backends-extra-service-2
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: httproute-multiple-extra-backends-extra-2


### PR DESCRIPTION
## Description of this PR

Previously the [experiment code](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/blob/main/pkg/plugin/experiment.go) removed all backend references it didn't recognize.

Now the plugin correctly looks at [rollout.Status.Canary.Weights.Additional](https://github.com/argoproj/argo-rollouts/blob/master/pkg/apis/rollouts/v1alpha1/types.go#L1063) and only removes what was actually added by the main Argo Rollouts controller. 

Should fix https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/issues/203

Also added local code coverage.

## Checklist:

* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] My build is green.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged
* [x] The tests actually define testcases about the feature/fix implemented
* [x] I have run all tests locally and they pass
* [x] I haven't changed the existing tests in a significant way, as this will break functionality for existing users <sup>1</sup>
* [ ] I've updated documentation as required by this PR.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY it works that way according to my use case
* [x] I understand what the code does and HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My new code is using existing utility functions instead of re-implementing everything again
* [x] Optional. My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md)

Notes

1. Unless a discussion has happened already in an issue and the breaking change is deemed acceptable
