### PR TITLE
fix: switch from logrus to hclog for structured plugin logs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -160,6 +160,22 @@ If you want to further fine-tune permissions:
 
 ## Configuration 
 
+### Log format
+
+By default the plugin logs in text format. To switch to JSON (useful when your log aggregation stack expects structured logs), pass `--logformat=json`:
+
+```yaml
+  trafficRouterPlugins: |-
+    - name: "argoproj-labs/gatewayAPI"
+      location: "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/vX.X.X/gatewayapi-plugin-linux-amd64"
+      args:
+      - "-logformat=json"
+```
+
+Note that the plugin runs as a separate process from the Argo Rollouts controller, so the log format must be configured independently for each.
+
+### Kubernetes client tuning
+
 The `kubeClientQPS` and `kubeClientBurst` options configure the behavior of the Kubernetes client. These
 values may need to be increased if you operate Argo Rollouts in a large cluster.  These values can be specified
 using the `args` block of the plugin configuration:

--- a/internal/utils/common.go
+++ b/internal/utils/common.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"os"
 	"strings"
 
 	pluginTypes "github.com/argoproj/argo-rollouts/utils/plugin/types"
@@ -23,10 +22,10 @@ func GetKubeConfig() (*rest.Config, error) {
 	return config, nil
 }
 
-func SetupLog() *log.Entry {
+func SetupLog(logFormat string) *log.Entry {
 	logger := log.New()
 	logger.SetLevel(log.InfoLevel)
-	if strings.EqualFold(os.Getenv("LOG_FORMAT"), "json") {
+	if strings.EqualFold(logFormat, "json") {
 		logger.SetFormatter(&log.JSONFormatter{})
 	} else {
 		logger.SetFormatter(&log.TextFormatter{FullTimestamp: true})

--- a/internal/utils/common.go
+++ b/internal/utils/common.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"os"
+	"strings"
+
 	pluginTypes "github.com/argoproj/argo-rollouts/utils/plugin/types"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
@@ -21,11 +24,12 @@ func GetKubeConfig() (*rest.Config, error) {
 }
 
 func SetupLog() *log.Entry {
-	log.SetLevel(log.InfoLevel)
-	log.SetFormatter(
-		&log.TextFormatter{
-			FullTimestamp: true,
-		},
-	)
-	return log.WithFields(log.Fields{"plugin": "trafficrouter"})
+	logger := log.New()
+	logger.SetLevel(log.InfoLevel)
+	if strings.EqualFold(os.Getenv("LOG_FORMAT"), "json") {
+		logger.SetFormatter(&log.JSONFormatter{})
+	} else {
+		logger.SetFormatter(&log.TextFormatter{FullTimestamp: true})
+	}
+	return logger.WithFields(log.Fields{"plugin": "trafficrouter"})
 }

--- a/internal/utils/common_test.go
+++ b/internal/utils/common_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"os"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -9,28 +8,28 @@ import (
 )
 
 func TestSetupLog_DefaultIsTextFormatter(t *testing.T) {
-	os.Unsetenv("LOG_FORMAT")
-	t.Cleanup(func() { os.Unsetenv("LOG_FORMAT") })
-
-	entry := SetupLog()
+	entry := SetupLog("text")
 
 	assert.NotNil(t, entry)
 	assert.IsType(t, &log.TextFormatter{}, entry.Logger.Formatter)
 }
 
-func TestSetupLog_JSONFormatterWhenEnvSet(t *testing.T) {
-	t.Setenv("LOG_FORMAT", "json")
+func TestSetupLog_EmptyIsTextFormatter(t *testing.T) {
+	entry := SetupLog("")
 
-	entry := SetupLog()
+	assert.NotNil(t, entry)
+	assert.IsType(t, &log.TextFormatter{}, entry.Logger.Formatter)
+}
+
+func TestSetupLog_JSONFormatter(t *testing.T) {
+	entry := SetupLog("json")
 
 	assert.NotNil(t, entry)
 	assert.IsType(t, &log.JSONFormatter{}, entry.Logger.Formatter)
 }
 
 func TestSetupLog_JSONFormatterCaseInsensitive(t *testing.T) {
-	t.Setenv("LOG_FORMAT", "JSON")
-
-	entry := SetupLog()
+	entry := SetupLog("JSON")
 
 	assert.NotNil(t, entry)
 	assert.IsType(t, &log.JSONFormatter{}, entry.Logger.Formatter)

--- a/internal/utils/common_test.go
+++ b/internal/utils/common_test.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"os"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetupLog_DefaultIsTextFormatter(t *testing.T) {
+	os.Unsetenv("LOG_FORMAT")
+	t.Cleanup(func() { os.Unsetenv("LOG_FORMAT") })
+
+	entry := SetupLog()
+
+	assert.NotNil(t, entry)
+	assert.IsType(t, &log.TextFormatter{}, entry.Logger.Formatter)
+}
+
+func TestSetupLog_JSONFormatterWhenEnvSet(t *testing.T) {
+	t.Setenv("LOG_FORMAT", "json")
+
+	entry := SetupLog()
+
+	assert.NotNil(t, entry)
+	assert.IsType(t, &log.JSONFormatter{}, entry.Logger.Formatter)
+}
+
+func TestSetupLog_JSONFormatterCaseInsensitive(t *testing.T) {
+	t.Setenv("LOG_FORMAT", "JSON")
+
+	entry := SetupLog()
+
+	assert.NotNil(t, entry)
+	assert.IsType(t, &log.JSONFormatter{}, entry.Logger.Formatter)
+}

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func main() {
 	// Define and parse flags for your command line options:
 	kubeClientQPS := flag.Int("kubeClientQPS", 5, "The QPS to use for the Kubernetes client.")
 	kubeClientBurst := flag.Int("kubeClientBurst", 10, "The Burst to use for the Kubernetes client.")
+	logFormat := flag.String("logformat", "text", "Set the logging format. One of: text|json")
 	flag.Parse()
 
 	// Create the plugin implementation, injecting command line options:
@@ -32,7 +33,7 @@ func main() {
 			KubeClientQPS:   float32(*kubeClientQPS),
 			KubeClientBurst: *kubeClientBurst,
 		},
-		LogCtx: utils.SetupLog(),
+		LogCtx: utils.SetupLog(*logFormat),
 	}
 
 	pluginMap := map[string]goPlugin.Plugin{

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -21,7 +21,7 @@ const (
 )
 
 func (r *RpcPlugin) InitPlugin() pluginTypes.RpcError {
-	log := utils.SetupLog()
+	log := r.LogCtx
 
 	kubeConfig, err := utils.GetKubeConfig()
 	if err != nil {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -32,7 +32,7 @@ func TestRunSuccessfully(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:              utils.SetupLog(),
+		LogCtx:              utils.SetupLog("text"),
 		GatewayAPIClientset: gwFake.NewSimpleClientset(&mocks.HTTPRouteObj, &mocks.GRPCRouteObj, &mocks.TCPPRouteObj, &mocks.TLSRouteObj),
 	}
 
@@ -935,7 +935,7 @@ func TestSetHTTPHeaderRouteWithExistingHeaders(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:              utils.SetupLog(),
+		LogCtx:              utils.SetupLog("text"),
 		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
 	}
 
@@ -1004,7 +1004,7 @@ func TestSetHTTPHeaderRouteWithExistingMethod(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:              utils.SetupLog(),
+		LogCtx:              utils.SetupLog("text"),
 		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
 	}
 
@@ -1070,7 +1070,7 @@ func TestSetHTTPHeaderRouteWithExistingQueryParams(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:              utils.SetupLog(),
+		LogCtx:              utils.SetupLog("text"),
 		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
 	}
 
@@ -1143,7 +1143,7 @@ func TestSetHTTPHeaderRouteWithMultipleExistingHeaders(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:              utils.SetupLog(),
+		LogCtx:              utils.SetupLog("text"),
 		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
 	}
 
@@ -1240,7 +1240,7 @@ func TestSetHTTPHeaderRouteWithCombinedMatches(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:              utils.SetupLog(),
+		LogCtx:              utils.SetupLog("text"),
 		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
 	}
 
@@ -1326,7 +1326,7 @@ func TestSetGRPCHeaderRouteWithExistingHeaders(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:              utils.SetupLog(),
+		LogCtx:              utils.SetupLog("text"),
 		GatewayAPIClientset: gwFake.NewSimpleClientset(grpcRoute),
 	}
 
@@ -1408,7 +1408,7 @@ func TestSetGRPCHeaderRouteWithMultipleExistingHeaders(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:              utils.SetupLog(),
+		LogCtx:              utils.SetupLog("text"),
 		GatewayAPIClientset: gwFake.NewSimpleClientset(grpcRoute),
 	}
 
@@ -1497,7 +1497,7 @@ func TestSetGRPCHeaderRouteWithMethodAndHeaders(t *testing.T) {
 
 	// Setup plugin
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:              utils.SetupLog(),
+		LogCtx:              utils.SetupLog("text"),
 		GatewayAPIClientset: gwFake.NewSimpleClientset(grpcRoute),
 	}
 
@@ -1579,7 +1579,7 @@ func TestSetHTTPHeaderRouteNoDuplicateOnRepeatedCall(t *testing.T) {
 	httpRoute := mocks.CreateHTTPRouteWithLabels(mocks.HTTPRouteName, nil)
 
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:              utils.SetupLog(),
+		LogCtx:              utils.SetupLog("text"),
 		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
 	}
 
@@ -1621,7 +1621,7 @@ func TestSetGRPCHeaderRouteNoDuplicateOnRepeatedCall(t *testing.T) {
 	grpcRoute := mocks.CreateGRPCRouteWithLabels(mocks.GRPCRouteName, nil)
 
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:              utils.SetupLog(),
+		LogCtx:              utils.SetupLog("text"),
 		GatewayAPIClientset: gwFake.NewSimpleClientset(grpcRoute),
 	}
 
@@ -1663,7 +1663,7 @@ func TestSetHTTPHeaderRouteTwoDistinctNamesAppendsBoth(t *testing.T) {
 	httpRoute := mocks.CreateHTTPRouteWithLabels(mocks.HTTPRouteName, nil)
 
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:              utils.SetupLog(),
+		LogCtx:              utils.SetupLog("text"),
 		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
 	}
 
@@ -1712,7 +1712,7 @@ func TestSetGRPCHeaderRouteTwoDistinctNamesAppendsBoth(t *testing.T) {
 	grpcRoute := mocks.CreateGRPCRouteWithLabels(mocks.GRPCRouteName, nil)
 
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:              utils.SetupLog(),
+		LogCtx:              utils.SetupLog("text"),
 		GatewayAPIClientset: gwFake.NewSimpleClientset(grpcRoute),
 	}
 
@@ -1908,7 +1908,7 @@ func TestSetWeightPreservesUnmanagedHTTPBackends(t *testing.T) {
 	}
 
 	rpcPluginImp := &RpcPlugin{
-		LogCtx:              utils.SetupLog(),
+		LogCtx:              utils.SetupLog("text"),
 		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute, &mocks.GRPCRouteObj, &mocks.TCPPRouteObj, &mocks.TLSRouteObj),
 	}
 	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{


### PR DESCRIPTION
## Description of this PR

When a plugin writes logs, go-plugin captures its stderr and re-emits lines through the host's internal hclog logger. If the plugin uses logrus (text or JSON), the host can't parse it and wraps the whole line as a string inside a DEBUG entry:

```
[DEBUG] plugin.gatewayAPI: {"level":"info","msg":"[SetWeight]..."}
```

This PR fixes the plugin side by replacing logrus with hclog throughout. Plugin logs are now written in hclog's native format (`@level`, `@message`, `@timestamp`), which the host's `logStderr` parser recognises and re-emits as proper structured fields — no wrapping, correct log levels.

The `--logformat text|json` flag (added in the previous commit) controls whether the plugin's own hclog logger uses JSON format, matching the convention used by the Argo Rollouts controller itself.

For the controller-side fix that makes `--logformat=json` actually flow into plugin subprocess loggers (traffic router, step, and metric provider), see: argoproj/argo-rollouts#4806

## Checklist:

* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] My build is green.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged
* [ ] The tests actually define testcases about the feature/fix implemented
* [ ] I have run all tests locally and they pass
* [ ] I haven't changed the existing tests in a significant way, as this will break functionality for existing users <sup>1</sup>
* [ ] I've updated documentation as required by this PR.
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY it works that way according to my use case
* [ ] I understand what the code does and HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My new code is using existing utility functions instead of re-implementing everything again

Notes

1. Unless a discussion has happened already in an issue and the breaking change is deemed acceptable