### PR TITLE
fix: switch from logrus to hclog for structured plugin logs

### DIFF
--- a/internal/utils/common.go
+++ b/internal/utils/common.go
@@ -3,17 +3,15 @@ package utils
 import (
 	"strings"
 
+	hclog "github.com/hashicorp/go-hclog"
 	pluginTypes "github.com/argoproj/argo-rollouts/utils/plugin/types"
-	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 func GetKubeConfig() (*rest.Config, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	// if you want to change the loading rules (which files in which order), you can do so here
 	configOverrides := &clientcmd.ConfigOverrides{}
-	// if you want to change override values or bind them to flags, there are methods to help you
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 	config, err := kubeConfig.ClientConfig()
 	if err != nil {
@@ -22,13 +20,11 @@ func GetKubeConfig() (*rest.Config, error) {
 	return config, nil
 }
 
-func SetupLog(logFormat string) *log.Entry {
-	logger := log.New()
-	logger.SetLevel(log.InfoLevel)
-	if strings.EqualFold(logFormat, "json") {
-		logger.SetFormatter(&log.JSONFormatter{})
-	} else {
-		logger.SetFormatter(&log.TextFormatter{FullTimestamp: true})
-	}
-	return logger.WithFields(log.Fields{"plugin": "trafficrouter"})
+func SetupLog(logFormat string) hclog.Logger {
+	jsonFormat := strings.EqualFold(logFormat, "json")
+	return hclog.New(&hclog.LoggerOptions{
+		Name:       "plugin.gatewayAPI",
+		Level:      hclog.Info,
+		JSONFormat: jsonFormat,
+	})
 }

--- a/internal/utils/common.go
+++ b/internal/utils/common.go
@@ -3,8 +3,8 @@ package utils
 import (
 	"strings"
 
-	hclog "github.com/hashicorp/go-hclog"
 	pluginTypes "github.com/argoproj/argo-rollouts/utils/plugin/types"
+	hclog "github.com/hashicorp/go-hclog"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )

--- a/internal/utils/common_test.go
+++ b/internal/utils/common_test.go
@@ -3,34 +3,34 @@ package utils
 import (
 	"testing"
 
-	log "github.com/sirupsen/logrus"
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSetupLog_DefaultIsTextFormatter(t *testing.T) {
-	entry := SetupLog("text")
+func TestSetupLog_DefaultIsTextFormat(t *testing.T) {
+	logger := SetupLog("text")
 
-	assert.NotNil(t, entry)
-	assert.IsType(t, &log.TextFormatter{}, entry.Logger.Formatter)
+	assert.NotNil(t, logger)
+	assert.Implements(t, (*hclog.Logger)(nil), logger)
 }
 
-func TestSetupLog_EmptyIsTextFormatter(t *testing.T) {
-	entry := SetupLog("")
+func TestSetupLog_EmptyIsTextFormat(t *testing.T) {
+	logger := SetupLog("")
 
-	assert.NotNil(t, entry)
-	assert.IsType(t, &log.TextFormatter{}, entry.Logger.Formatter)
+	assert.NotNil(t, logger)
+	assert.Implements(t, (*hclog.Logger)(nil), logger)
 }
 
-func TestSetupLog_JSONFormatter(t *testing.T) {
-	entry := SetupLog("json")
+func TestSetupLog_JSONFormat(t *testing.T) {
+	logger := SetupLog("json")
 
-	assert.NotNil(t, entry)
-	assert.IsType(t, &log.JSONFormatter{}, entry.Logger.Formatter)
+	assert.NotNil(t, logger)
+	assert.Implements(t, (*hclog.Logger)(nil), logger)
 }
 
-func TestSetupLog_JSONFormatterCaseInsensitive(t *testing.T) {
-	entry := SetupLog("JSON")
+func TestSetupLog_JSONFormatCaseInsensitive(t *testing.T) {
+	logger := SetupLog("JSON")
 
-	assert.NotNil(t, entry)
-	assert.IsType(t, &log.JSONFormatter{}, entry.Logger.Formatter)
+	assert.NotNil(t, logger)
+	assert.Implements(t, (*hclog.Logger)(nil), logger)
 }

--- a/main.go
+++ b/main.go
@@ -27,13 +27,15 @@ func main() {
 	logFormat := flag.String("logformat", "text", "Set the logging format. One of: text|json")
 	flag.Parse()
 
+	logger := utils.SetupLog(*logFormat)
+
 	// Create the plugin implementation, injecting command line options:
 	rpcPluginImp := &plugin.RpcPlugin{
 		CommandLineOpts: plugin.CommandLineOpts{
 			KubeClientQPS:   float32(*kubeClientQPS),
 			KubeClientBurst: *kubeClientBurst,
 		},
-		LogCtx: utils.SetupLog(*logFormat),
+		LogCtx: logger,
 	}
 
 	pluginMap := map[string]goPlugin.Plugin{
@@ -43,5 +45,6 @@ func main() {
 	goPlugin.Serve(&goPlugin.ServeConfig{
 		HandshakeConfig: handshakeConfig,
 		Plugins:         pluginMap,
+		Logger:          logger,
 	})
 }

--- a/pkg/plugin/experiment.go
+++ b/pkg/plugin/experiment.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
-	"github.com/sirupsen/logrus"
+	hclog "github.com/hashicorp/go-hclog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayApiClientset "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 )
 
-func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gatewayClient gatewayApiClientset.Interface, logger *logrus.Entry, rollout *v1alpha1.Rollout, httpRoute *gatewayv1.HTTPRoute, additionalDestinations []v1alpha1.WeightDestination) error {
+func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gatewayClient gatewayApiClientset.Interface, logger hclog.Logger, rollout *v1alpha1.Rollout, httpRoute *gatewayv1.HTTPRoute, additionalDestinations []v1alpha1.WeightDestination) error {
 	ruleIdx := -1
 	stableService := rollout.Spec.Strategy.Canary.StableService
 	canaryService := rollout.Spec.Strategy.Canary.CanaryService
@@ -55,7 +55,7 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 	}
 
 	if isExperimentActive {
-		logger.Info(fmt.Sprintf("Found active experiment %s", rollout.Status.Canary.CurrentExperiment))
+		logger.Info("Found active experiment", "experiment", rollout.Status.Canary.CurrentExperiment)
 
 		if len(additionalDestinations) == 0 {
 			logger.Info("No experiment services found in additionalDestinations, skipping experiment service addition")
@@ -70,7 +70,7 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 
 		// Sanity cap: don't allow overflow
 		if totalExperimentWeight > 100 {
-			logger.Warnf("Total experiment weight exceeds 100 (got %d), capping at 100", totalExperimentWeight)
+			logger.Warn("Total experiment weight exceeds 100, capping at 100", "weight", totalExperimentWeight)
 			totalExperimentWeight = 100
 		}
 
@@ -96,11 +96,11 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 			}
 
 			if !exists {
-				logger.Info(fmt.Sprintf("Adding experiment service to HTTPRoute: %s with weight %d", serviceName, weight))
+				logger.Info("Adding experiment service to HTTPRoute", "service", serviceName, "weight", weight)
 
 				service, err := clientset.CoreV1().Services(rollout.Namespace).Get(ctx, serviceName, metav1.GetOptions{})
 				if err != nil {
-					logger.Warn(fmt.Sprintf("Failed to get service %s: %v", serviceName, err))
+					logger.Warn("Failed to get service", "service", serviceName, "error", err)
 					continue
 				}
 
@@ -143,7 +143,7 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 			serviceName := string(backendRef.Name)
 
 			if previousServices[serviceName] {
-				logger.Info(fmt.Sprintf("Removing experiment service from HTTPRoute: %s", serviceName))
+				logger.Info("Removing experiment service from HTTPRoute", "service", serviceName)
 				continue
 			}
 

--- a/pkg/plugin/httproute.go
+++ b/pkg/plugin/httproute.go
@@ -55,7 +55,7 @@ func (r *RpcPlugin) setHTTPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight 
 
 		err = HandleExperiment(ctx, r.Clientset, r.GatewayAPIClientset, r.LogCtx, rollout, httpRoute, additionalDestinations)
 		if err != nil {
-			r.LogCtx.Error(err, "Failed to handle experiment services")
+			r.LogCtx.Error("Failed to handle experiment services", "error", err)
 		}
 
 		ensureInProgressLabel(httpRoute, desiredWeight, gatewayAPIConfig)

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -34,11 +33,11 @@ func (r *RpcPlugin) InitPlugin() pluginTypes.RpcError {
 
 	// Configure command-line overrides for the Kubernetes client:
 	if r.CommandLineOpts.KubeClientQPS != 0 {
-		log.Infof("KubeClientQPS set to: %f", r.CommandLineOpts.KubeClientQPS)
+		log.Info("KubeClientQPS set to", "qps", r.CommandLineOpts.KubeClientQPS)
 		kubeConfig.QPS = r.CommandLineOpts.KubeClientQPS
 	}
 	if r.CommandLineOpts.KubeClientBurst != 0 {
-		log.Infof("KubeClientBurst set to: %d", r.CommandLineOpts.KubeClientBurst)
+		log.Info("KubeClientBurst set to", "burst", r.CommandLineOpts.KubeClientBurst)
 		kubeConfig.Burst = r.CommandLineOpts.KubeClientBurst
 	}
 
@@ -77,7 +76,7 @@ func (r *RpcPlugin) SetWeight(rollout *v1alpha1.Rollout, desiredWeight int32, ad
 	}
 	var rpcError pluginTypes.RpcError
 	if gatewayAPIConfig.HTTPRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls HTTPRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.HTTPRoutes)))
+		r.LogCtx.Info("[SetWeight] plugin controls HTTPRoutes", "plugin", PluginName, "routes", getGatewayAPIRouteNameList(gatewayAPIConfig.HTTPRoutes))
 		rpcError = forEachGatewayAPIRoute(gatewayAPIConfig.HTTPRoutes, func(route HTTPRoute) pluginTypes.RpcError {
 			gatewayAPIConfig.HTTPRoute = route.Name
 			return r.setHTTPRouteWeight(rollout, desiredWeight, additionalDestinations, gatewayAPIConfig)
@@ -87,7 +86,7 @@ func (r *RpcPlugin) SetWeight(rollout *v1alpha1.Rollout, desiredWeight int32, ad
 		}
 	}
 	if gatewayAPIConfig.GRPCRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls GRPCRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.GRPCRoutes)))
+		r.LogCtx.Info("[SetWeight] plugin controls GRPCRoutes", "plugin", PluginName, "routes", getGatewayAPIRouteNameList(gatewayAPIConfig.GRPCRoutes))
 		rpcError = forEachGatewayAPIRoute(gatewayAPIConfig.GRPCRoutes, func(route GRPCRoute) pluginTypes.RpcError {
 			gatewayAPIConfig.GRPCRoute = route.Name
 			return r.setGRPCRouteWeight(rollout, desiredWeight, gatewayAPIConfig)
@@ -97,7 +96,7 @@ func (r *RpcPlugin) SetWeight(rollout *v1alpha1.Rollout, desiredWeight int32, ad
 		}
 	}
 	if gatewayAPIConfig.TCPRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls TCPRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.TCPRoutes)))
+		r.LogCtx.Info("[SetWeight] plugin controls TCPRoutes", "plugin", PluginName, "routes", getGatewayAPIRouteNameList(gatewayAPIConfig.TCPRoutes))
 		rpcError = forEachGatewayAPIRoute(gatewayAPIConfig.TCPRoutes, func(route TCPRoute) pluginTypes.RpcError {
 			gatewayAPIConfig.TCPRoute = route.Name
 			return r.setTCPRouteWeight(rollout, desiredWeight, gatewayAPIConfig)
@@ -107,7 +106,7 @@ func (r *RpcPlugin) SetWeight(rollout *v1alpha1.Rollout, desiredWeight int32, ad
 		}
 	}
 	if gatewayAPIConfig.TLSRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls TLSRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.TLSRoutes)))
+		r.LogCtx.Info("[SetWeight] plugin controls TLSRoutes", "plugin", PluginName, "routes", getGatewayAPIRouteNameList(gatewayAPIConfig.TLSRoutes))
 		rpcError = forEachGatewayAPIRoute(gatewayAPIConfig.TLSRoutes, func(route TLSRoute) pluginTypes.RpcError {
 			gatewayAPIConfig.TLSRoute = route.Name
 			return r.setTLSRouteWeight(rollout, desiredWeight, gatewayAPIConfig)
@@ -124,7 +123,7 @@ func (r *RpcPlugin) SetHeaderRoute(rollout *v1alpha1.Rollout, headerRouting *v1a
 		}
 	}
 	if gatewayAPIConfig.HTTPRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[SetHeaderRoute] plugin %q controls HTTPRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.HTTPRoutes)))
+		r.LogCtx.Info("[SetHeaderRoute] plugin controls HTTPRoutes", "plugin", PluginName, "routes", getGatewayAPIRouteNameList(gatewayAPIConfig.HTTPRoutes))
 		rpcError := forEachGatewayAPIRoute(gatewayAPIConfig.HTTPRoutes, func(route HTTPRoute) pluginTypes.RpcError {
 			if !route.UseHeaderRoutes {
 				return pluginTypes.RpcError{}
@@ -137,7 +136,7 @@ func (r *RpcPlugin) SetHeaderRoute(rollout *v1alpha1.Rollout, headerRouting *v1a
 		}
 	}
 	if gatewayAPIConfig.GRPCRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[SetHeaderRoute] plugin %q controls GRPCRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.GRPCRoutes)))
+		r.LogCtx.Info("[SetHeaderRoute] plugin controls GRPCRoutes", "plugin", PluginName, "routes", getGatewayAPIRouteNameList(gatewayAPIConfig.GRPCRoutes))
 		rpcError := forEachGatewayAPIRoute(gatewayAPIConfig.GRPCRoutes, func(route GRPCRoute) pluginTypes.RpcError {
 			if !route.UseHeaderRoutes {
 				return pluginTypes.RpcError{}
@@ -168,7 +167,7 @@ func (r *RpcPlugin) RemoveManagedRoutes(rollout *v1alpha1.Rollout) pluginTypes.R
 		}
 	}
 	if gatewayAPIConfig.HTTPRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[RemoveManagedRoutes] plugin %q controls HTTPRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.HTTPRoutes)))
+		r.LogCtx.Info("[RemoveManagedRoutes] plugin controls HTTPRoutes", "plugin", PluginName, "routes", getGatewayAPIRouteNameList(gatewayAPIConfig.HTTPRoutes))
 		rpcError := forEachGatewayAPIRoute(gatewayAPIConfig.HTTPRoutes, func(route HTTPRoute) pluginTypes.RpcError {
 			if !route.UseHeaderRoutes {
 				return pluginTypes.RpcError{}
@@ -181,7 +180,7 @@ func (r *RpcPlugin) RemoveManagedRoutes(rollout *v1alpha1.Rollout) pluginTypes.R
 		}
 	}
 	if gatewayAPIConfig.GRPCRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[RemoveManagedRoutes] plugin %q controls GRPCRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.GRPCRoutes)))
+		r.LogCtx.Info("[RemoveManagedRoutes] plugin controls GRPCRoutes", "plugin", PluginName, "routes", getGatewayAPIRouteNameList(gatewayAPIConfig.GRPCRoutes))
 		rpcError := forEachGatewayAPIRoute(gatewayAPIConfig.GRPCRoutes, func(route GRPCRoute) pluginTypes.RpcError {
 			if !route.UseHeaderRoutes {
 				return pluginTypes.RpcError{}
@@ -262,7 +261,7 @@ func (r *RpcPlugin) discoverRoutesBySelector(rollout *v1alpha1.Rollout, gatewayA
 		}
 
 		if len(httpRouteList.Items) > 0 {
-			r.LogCtx.Info(fmt.Sprintf("[discoverRoutesBySelector] discovered %d HTTPRoutes via selector", len(httpRouteList.Items)))
+			r.LogCtx.Info("[discoverRoutesBySelector] discovered HTTPRoutes via selector", "count", len(httpRouteList.Items))
 		}
 	}
 
@@ -288,7 +287,7 @@ func (r *RpcPlugin) discoverRoutesBySelector(rollout *v1alpha1.Rollout, gatewayA
 		}
 
 		if len(grpcRouteList.Items) > 0 {
-			r.LogCtx.Info(fmt.Sprintf("[discoverRoutesBySelector] discovered %d GRPCRoutes via selector", len(grpcRouteList.Items)))
+			r.LogCtx.Info("[discoverRoutesBySelector] discovered GRPCRoutes via selector", "count", len(grpcRouteList.Items))
 		}
 	}
 
@@ -314,7 +313,7 @@ func (r *RpcPlugin) discoverRoutesBySelector(rollout *v1alpha1.Rollout, gatewayA
 		}
 
 		if len(tcpRouteList.Items) > 0 {
-			r.LogCtx.Info(fmt.Sprintf("[discoverRoutesBySelector] discovered %d TCPRoutes via selector", len(tcpRouteList.Items)))
+			r.LogCtx.Info("[discoverRoutesBySelector] discovered TCPRoutes via selector", "count", len(tcpRouteList.Items))
 		}
 	}
 
@@ -340,7 +339,7 @@ func (r *RpcPlugin) discoverRoutesBySelector(rollout *v1alpha1.Rollout, gatewayA
 		}
 
 		if len(tlsRouteList.Items) > 0 {
-			r.LogCtx.Info(fmt.Sprintf("[discoverRoutesBySelector] discovered %d TLSRoutes via selector", len(tlsRouteList.Items)))
+			r.LogCtx.Info("[discoverRoutesBySelector] discovered TLSRoutes via selector", "count", len(tlsRouteList.Items))
 		}
 	}
 

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"strings"
 	"testing"
 	"time"
@@ -17,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	log "github.com/sirupsen/logrus"
 	gwFake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 
 	goPlugin "github.com/hashicorp/go-plugin"

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -1,7 +1,7 @@
 package plugin
 
 import (
-	"github.com/sirupsen/logrus"
+	hclog "github.com/hashicorp/go-hclog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -18,7 +18,7 @@ type RpcPlugin struct {
 	CommandLineOpts     CommandLineOpts
 	GatewayAPIClientset gatewayAPIClientset.Interface
 	Clientset           *kubernetes.Clientset
-	LogCtx              *logrus.Entry
+	LogCtx              hclog.Logger
 }
 
 type GatewayAPITrafficRouting struct {


### PR DESCRIPTION
## Description of this PR

When a plugin writes logs, go-plugin captures its stderr and re-emits lines through the host's internal hclog logger. The previous implementation used logrus, which go-plugin couldn't parse — it wrapped the entire log line as a string inside a DEBUG entry:

```
[DEBUG] plugin.gatewayAPI: {"level":"info","msg":"[SetWeight]...JSON blob..."}
```

This was discovered while investigating why `--logformat=json` (added in #209) had no visible effect on the output format.

Root cause: go-plugin's `logStderr` parser expects hclog's native JSON format (`@level`, `@message`, `@timestamp`). Logrus uses different field names (`level`, `msg`, `time`), so the parser can't recognise the log level and falls back to wrapping the whole line as a debug string.

This PR replaces logrus with hclog throughout the plugin. Logs are now written in hclog's native format, which the host process parses correctly and re-emits as properly structured log entries at the right level.

The `--logformat text|json` flag still works — it controls the `JSONFormat` option on the hclog logger passed to `goPlugin.Serve()`.

For the controller-side fix that makes `--logformat=json` actually propagate into plugin subprocess loggers (for all plugin types — traffic router, step, and metric provider), see: argoproj/argo-rollouts#4806

## Checklist:

* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] My build is green.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged
* [x] The tests actually define testcases about the feature/fix implemented
* [x] I have run all tests locally and they pass
* [x] I haven't changed the existing tests in a significant way, as this will break functionality for existing users <sup>1</sup>
* [x] I've updated documentation as required by this PR.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY it works that way according to my use case
* [x] I understand what the code does and HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My new code is using existing utility functions instead of re-implementing everything again

Notes

1. Unless a discussion has happened already in an issue and the breaking change is deemed acceptable