### PR TITLE
ci: add codecov support

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,20 @@
+flags:
+  unit-tests:
+    carryforward: true
+coverage:
+  status:
+    # allow test coverage to drop by 0.1%, assume that it's typically due to CI problems
+    patch:
+      default:
+        threshold: 0.1
+    project:
+      default:
+        threshold: 0.1
+ignore:
+  - '**/*_test.go'
+  - '**/mocks/*'
+  - 'main.go'
+  - 'test'
+  - 'examples'
+  - 'docs'
+  - 'vendor/.*'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,19 @@ jobs:
 
       - name: Unit tests running
         run: |
-          make unit-tests
+          make coverage
+
+      - name: Upload unit test coverage to codecov.io
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: coverage.out
+          flags: unit-tests
+          fail_ci_if_error: false
+          codecov_yml_path: .codecov.yml
+          disable_search: true
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   e2e-tests:
     name: E2E tests 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 **Code:**
 [![Go Report Card](https://goreportcard.com/badge/github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi)](https://goreportcard.com/report/github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi)
 [![Gateway API plugin CI](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/actions/workflows/ci.yaml/badge.svg)](https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/gh/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/branch/main/graph/badge.svg)](https://codecov.io/gh/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi)
 
 **Social:**
 [![Twitter Follow](https://img.shields.io/twitter/follow/argoproj?style=social)](https://twitter.com/argoproj)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -91,6 +91,14 @@ To run unit tests:
 make unit-tests
 ```
 
+To also measure coverage, which writes `coverage.out` and a browsable `coverage.html`:
+```bash
+make coverage
+```
+
+CI uploads the unit test coverage profile to [Codecov](https://codecov.io/gh/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi),
+so pull requests get a coverage report as a comment. New code is expected to come with tests.
+
 ## Running E2E tests
 
 The e2e tests need a Kubernetes cluster with Argo Rollouts and Traefik installed. 


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Description of this PR

Added Codecoveage similar to Argo Rollouts

Closes https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/issues/205

## Checklist:

* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] My build is green.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged
* [ ] The tests actually define testcases about the feature/fix implemented
* [ ] I have run all tests locally and they pass
* [ ] I haven't changed the existing tests in a significant way, as this will break functionality for existing users <sup>1</sup>
* [ ] I've updated documentation as required by this PR.
* [ ] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [ ] I understand what the code does and WHY it works that way according to my use case
* [ ] I understand what the code does and HOW it works in several scenarios
* [ ] I know if my code is just adding new functionality or changing old functionality for existing users
* [ ] My new code is using existing utility functions instead of re-implementing everything again
* [ ] Optional. My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md)

Notes

1. Unless a discussion has happened already in an issue and the breaking change is deemed acceptable
