### PR TITLE
fix: calculate experiment canary weights correctly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Install Chainsaw
         uses: kyverno/action-install-chainsaw@v0.1.0
         with:
-          release: v0.2.14
+          release: v0.2.15
       - name: Check install
         run: chainsaw version
       - name: Set up Kind

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@ dist
 .idea
 coverage.out
 coverage.html
-chainsaw-report.hml
 chainsaw-report.xml
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .idea
 coverage.out
 coverage.html
+chainsaw-report.html

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CURRENT_DIR=$(shell pwd)
 DIST_DIR=${CURRENT_DIR}/dist
 E2E_CLUSTER_NAME=gatewayapi-plugin-e2e
 IS_E2E_CLUSTER=$(shell kind get clusters | grep -e "^${E2E_CLUSTER_NAME}$$")
-CHAINSAW_VERSION=v0.2.12
+CHAINSAW_VERSION=v0.2.15
 
 # Versions of components used in e2e tests
 GATEWAY_API_VERSION=v1.4.0
@@ -90,4 +90,3 @@ endif
 .PHONY: serve-docs
 serve-docs:  ## serve docs locally
 	docker run --rm -it -p 8000:8000 -v ${CURRENT_DIR}:/docs squidfunk/mkdocs-material serve -a 0.0.0.0:8000
-

--- a/pkg/plugin/experiment.go
+++ b/pkg/plugin/experiment.go
@@ -34,7 +34,7 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 		return fmt.Errorf("no matching rule found for rollout %s", rollout.Name)
 	}
 
-	isExperimentActive := rollout.Spec.Strategy.Canary != nil && rollout.Status.Canary.CurrentExperiment != ""
+	isExperimentActive := rollout.Spec.Strategy.Canary != nil && rollout.Status.Canary.CurrentExperiment != "" && len(additionalDestinations) > 0
 
 	// previousServices are the experiment services the controller told the plugin to add
 	// on the previous reconcile, recorded in the rollout status. These are the only
@@ -57,11 +57,6 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 
 	if isExperimentActive {
 		logger.Info(fmt.Sprintf("Found active experiment %s", rollout.Status.Canary.CurrentExperiment))
-
-		if len(additionalDestinations) == 0 {
-			logger.Info("No experiment services found in additionalDestinations, skipping experiment service addition")
-			return nil
-		}
 
 		// Preserve the canary allocation established by SetWeight. Experiment
 		// destinations consume traffic in addition to canary, so only the

--- a/pkg/plugin/experiment.go
+++ b/pkg/plugin/experiment.go
@@ -3,8 +3,6 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"sort"
-	"strings"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/weightutil"
@@ -14,8 +12,6 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayApiClientset "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 )
-
-const experimentServicesAnnotation = "rollouts.argoproj.io/gatewayapi-experiment-services"
 
 func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gatewayClient gatewayApiClientset.Interface, logger *logrus.Entry, rollout *v1alpha1.Rollout, httpRoute *gatewayv1.HTTPRoute, additionalDestinations []v1alpha1.WeightDestination) error {
 	ruleIdx := -1
@@ -40,15 +36,22 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 
 	isExperimentActive := rollout.Spec.Strategy.Canary != nil && rollout.Status.Canary.CurrentExperiment != ""
 
-	// Keep ownership on the route because Argo Rollouts can clear the additional
-	// destinations from status before it clears CurrentExperiment. Status remains
-	// a fallback for routes created by plugin versions that predate the annotation.
-	experimentServices := experimentServicesFromHTTPRoute(httpRoute)
+	// previousServices are the experiment services the controller told the plugin to add
+	// on the previous reconcile, recorded in the rollout status. These are the only
+	// backends the plugin owns and may remove; any other backend in the route is managed
+	// externally and must be left untouched (issue #203).
+	previousServices := make(map[string]bool)
 	if rollout.Status.Canary.Weights != nil {
 		for _, dest := range rollout.Status.Canary.Weights.Additional {
-			if dest.ServiceName != "" {
-				experimentServices[dest.ServiceName] = true
-			}
+			previousServices[dest.ServiceName] = true
+		}
+	}
+
+	hasExperimentServices := false
+	for _, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
+		if previousServices[string(backendRef.Name)] {
+			hasExperimentServices = true
+			break
 		}
 	}
 
@@ -59,13 +62,6 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 			logger.Info("No experiment services found in additionalDestinations, skipping experiment service addition")
 			return nil
 		}
-
-		for _, dest := range additionalDestinations {
-			if dest.ServiceName != "" {
-				experimentServices[dest.ServiceName] = true
-			}
-		}
-		setExperimentServicesAnnotation(httpRoute, experimentServices)
 
 		// Preserve the canary allocation established by SetWeight. Experiment
 		// destinations consume traffic in addition to canary, so only the
@@ -149,7 +145,7 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 		return nil
 	}
 
-	if !isExperimentActive && len(experimentServices) > 0 {
+	if !isExperimentActive && hasExperimentServices {
 		logger.Info("Experiment is no longer active, removing experiment services from HTTPRoute")
 
 		stableWeight := weightutil.MaxTrafficWeight(rollout)
@@ -158,7 +154,7 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 		for _, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
 			serviceName := string(backendRef.Name)
 
-			if experimentServices[serviceName] {
+			if previousServices[serviceName] {
 				logger.Info(fmt.Sprintf("Removing experiment service from HTTPRoute: %s", serviceName))
 				continue
 			}
@@ -174,43 +170,8 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 		}
 
 		httpRoute.Spec.Rules[ruleIdx].BackendRefs = filteredBackendRefs
-		setExperimentServicesAnnotation(httpRoute, nil)
 		logger.Info("Experiment services removed from HTTPRoute")
 	}
 
 	return nil
-}
-
-func experimentServicesFromHTTPRoute(httpRoute *gatewayv1.HTTPRoute) map[string]bool {
-	services := make(map[string]bool)
-	for serviceName := range strings.SplitSeq(httpRoute.Annotations[experimentServicesAnnotation], ",") {
-		if serviceName != "" {
-			services[serviceName] = true
-		}
-	}
-	return services
-}
-
-func setExperimentServicesAnnotation(httpRoute *gatewayv1.HTTPRoute, services map[string]bool) {
-	annotations := httpRoute.GetAnnotations()
-	if len(services) == 0 {
-		delete(annotations, experimentServicesAnnotation)
-		if len(annotations) == 0 {
-			httpRoute.SetAnnotations(nil)
-		} else {
-			httpRoute.SetAnnotations(annotations)
-		}
-		return
-	}
-
-	serviceNames := make([]string, 0, len(services))
-	for serviceName := range services {
-		serviceNames = append(serviceNames, serviceName)
-	}
-	sort.Strings(serviceNames)
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-	annotations[experimentServicesAnnotation] = strings.Join(serviceNames, ",")
-	httpRoute.SetAnnotations(annotations)
 }

--- a/pkg/plugin/experiment.go
+++ b/pkg/plugin/experiment.go
@@ -3,6 +3,8 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/weightutil"
@@ -12,6 +14,8 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayApiClientset "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 )
+
+const experimentServicesAnnotation = "rollouts.argoproj.io/gatewayapi-experiment-services"
 
 func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gatewayClient gatewayApiClientset.Interface, logger *logrus.Entry, rollout *v1alpha1.Rollout, httpRoute *gatewayv1.HTTPRoute, additionalDestinations []v1alpha1.WeightDestination) error {
 	ruleIdx := -1
@@ -36,22 +40,15 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 
 	isExperimentActive := rollout.Spec.Strategy.Canary != nil && rollout.Status.Canary.CurrentExperiment != ""
 
-	// previousServices are the experiment services the controller told the plugin to add
-	// on the previous reconcile, recorded in the rollout status. These are the only
-	// backends the plugin owns and may remove; any other backend in the route is managed
-	// externally and must be left untouched (issue #203).
-	previousServices := make(map[string]bool)
+	// Keep ownership on the route because Argo Rollouts can clear the additional
+	// destinations from status before it clears CurrentExperiment. Status remains
+	// a fallback for routes created by plugin versions that predate the annotation.
+	experimentServices := experimentServicesFromHTTPRoute(httpRoute)
 	if rollout.Status.Canary.Weights != nil {
 		for _, dest := range rollout.Status.Canary.Weights.Additional {
-			previousServices[dest.ServiceName] = true
-		}
-	}
-
-	hasExperimentServices := false
-	for _, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
-		if previousServices[string(backendRef.Name)] {
-			hasExperimentServices = true
-			break
+			if dest.ServiceName != "" {
+				experimentServices[dest.ServiceName] = true
+			}
 		}
 	}
 
@@ -63,20 +60,37 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 			return nil
 		}
 
-		// Compute total experiment weight
-		var totalExperimentWeight int32
 		for _, dest := range additionalDestinations {
-			totalExperimentWeight += dest.Weight
+			if dest.ServiceName != "" {
+				experimentServices[dest.ServiceName] = true
+			}
+		}
+		setExperimentServicesAnnotation(httpRoute, experimentServices)
+
+		// Preserve the canary allocation established by SetWeight. Experiment
+		// destinations consume traffic in addition to canary, so only the
+		// remainder belongs to stable.
+		var canaryWeight int32
+		for _, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
+			if string(backendRef.Name) == canaryService && backendRef.Weight != nil {
+				canaryWeight = *backendRef.Weight
+				break
+			}
 		}
 
-		// Sanity cap: don't allow overflow
+		var totalExperimentWeight int64
+		for _, dest := range additionalDestinations {
+			totalExperimentWeight += int64(dest.Weight)
+		}
+
 		maxWeight := weightutil.MaxTrafficWeight(rollout)
-		if totalExperimentWeight > maxWeight {
-			logger.Warnf("Total experiment weight exceeds maxTrafficWeight %d (got %d), capping at %d", maxWeight, totalExperimentWeight, maxWeight)
-			totalExperimentWeight = maxWeight
+		totalAllocatedWeight := int64(canaryWeight) + totalExperimentWeight
+		stableWeight := int32(0)
+		if totalAllocatedWeight < int64(maxWeight) {
+			stableWeight = maxWeight - int32(totalAllocatedWeight)
+		} else if totalAllocatedWeight > int64(maxWeight) {
+			logger.Warnf("Combined canary and experiment weight exceeds maxTrafficWeight %d (got %d), setting stable weight to 0", maxWeight, totalAllocatedWeight)
 		}
-
-		stableWeight := maxWeight - totalExperimentWeight
 
 		for i, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
 			if string(backendRef.Name) == stableService {
@@ -135,7 +149,7 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 		return nil
 	}
 
-	if !isExperimentActive && hasExperimentServices {
+	if !isExperimentActive && len(experimentServices) > 0 {
 		logger.Info("Experiment is no longer active, removing experiment services from HTTPRoute")
 
 		stableWeight := weightutil.MaxTrafficWeight(rollout)
@@ -144,7 +158,7 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 		for _, backendRef := range httpRoute.Spec.Rules[ruleIdx].BackendRefs {
 			serviceName := string(backendRef.Name)
 
-			if previousServices[serviceName] {
+			if experimentServices[serviceName] {
 				logger.Info(fmt.Sprintf("Removing experiment service from HTTPRoute: %s", serviceName))
 				continue
 			}
@@ -160,8 +174,43 @@ func HandleExperiment(ctx context.Context, clientset *kubernetes.Clientset, gate
 		}
 
 		httpRoute.Spec.Rules[ruleIdx].BackendRefs = filteredBackendRefs
+		setExperimentServicesAnnotation(httpRoute, nil)
 		logger.Info("Experiment services removed from HTTPRoute")
 	}
 
 	return nil
+}
+
+func experimentServicesFromHTTPRoute(httpRoute *gatewayv1.HTTPRoute) map[string]bool {
+	services := make(map[string]bool)
+	for serviceName := range strings.SplitSeq(httpRoute.Annotations[experimentServicesAnnotation], ",") {
+		if serviceName != "" {
+			services[serviceName] = true
+		}
+	}
+	return services
+}
+
+func setExperimentServicesAnnotation(httpRoute *gatewayv1.HTTPRoute, services map[string]bool) {
+	annotations := httpRoute.GetAnnotations()
+	if len(services) == 0 {
+		delete(annotations, experimentServicesAnnotation)
+		if len(annotations) == 0 {
+			httpRoute.SetAnnotations(nil)
+		} else {
+			httpRoute.SetAnnotations(annotations)
+		}
+		return
+	}
+
+	serviceNames := make([]string, 0, len(services))
+	for serviceName := range services {
+		serviceNames = append(serviceNames, serviceName)
+	}
+	sort.Strings(serviceNames)
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[experimentServicesAnnotation] = strings.Join(serviceNames, ",")
+	httpRoute.SetAnnotations(annotations)
 }

--- a/pkg/plugin/experiment_test.go
+++ b/pkg/plugin/experiment_test.go
@@ -268,7 +268,6 @@ func TestHandleExperimentPreservesCanaryWeight(t *testing.T) {
 	assert.Equal(t, int32(20), *httpRoute.Spec.Rules[0].BackendRefs[1].Weight)
 	assert.Equal(t, int32(10), *httpRoute.Spec.Rules[0].BackendRefs[2].Weight)
 	assert.Equal(t, int32(10), *httpRoute.Spec.Rules[0].BackendRefs[3].Weight)
-	assert.Equal(t, "exp-svc-1,exp-svc-2", httpRoute.Annotations[experimentServicesAnnotation])
 }
 
 func TestHandleExperimentFloorsStableWeightWhenExperimentWeightsExceedMaxTrafficWeight(t *testing.T) {
@@ -313,29 +312,6 @@ func TestHandleExperimentCleanupRestoresMaxTrafficWeight(t *testing.T) {
 	require.Len(t, httpRoute.Spec.Rules[0].BackendRefs, 2)
 	assert.Equal(t, int32(100000), *httpRoute.Spec.Rules[0].BackendRefs[0].Weight)
 	assert.Equal(t, int32(0), *httpRoute.Spec.Rules[0].BackendRefs[1].Weight)
-}
-
-func TestHandleExperimentCleanupUsesRouteOwnershipAfterRolloutStatusIsCleared(t *testing.T) {
-	rollout := experimentRollout(100, "")
-	httpRoute := experimentHTTPRoute(
-		backendRef("stable-svc", 100),
-		backendRef("canary-svc", 0),
-		backendRef("exp-svc-1", 10),
-		backendRef("unmanaged-svc", 5),
-		backendRef("exp-svc-2", 10),
-	)
-	httpRoute.Annotations = map[string]string{
-		experimentServicesAnnotation: "exp-svc-1,exp-svc-2",
-	}
-
-	err := HandleExperiment(context.Background(), nil, nil, testLogger(), rollout, httpRoute, nil)
-
-	require.NoError(t, err)
-	require.Len(t, httpRoute.Spec.Rules[0].BackendRefs, 3)
-	assert.Equal(t, gatewayv1.ObjectName("stable-svc"), httpRoute.Spec.Rules[0].BackendRefs[0].Name)
-	assert.Equal(t, gatewayv1.ObjectName("canary-svc"), httpRoute.Spec.Rules[0].BackendRefs[1].Name)
-	assert.Equal(t, gatewayv1.ObjectName("unmanaged-svc"), httpRoute.Spec.Rules[0].BackendRefs[2].Name)
-	assert.NotContains(t, httpRoute.Annotations, experimentServicesAnnotation)
 }
 
 func experimentRollout(maxWeight int32, currentExperiment string) *v1alpha1.Rollout {

--- a/pkg/plugin/experiment_test.go
+++ b/pkg/plugin/experiment_test.go
@@ -314,6 +314,33 @@ func TestHandleExperimentCleanupRestoresMaxTrafficWeight(t *testing.T) {
 	assert.Equal(t, int32(0), *httpRoute.Spec.Rules[0].BackendRefs[1].Weight)
 }
 
+func TestHandleExperimentCleansUpBeforeCurrentExperimentIsCleared(t *testing.T) {
+	rollout := experimentRollout(100, "active-experiment")
+	rollout.Status.Canary.Weights = &v1alpha1.TrafficWeights{
+		Additional: []v1alpha1.WeightDestination{
+			{ServiceName: "exp-svc-1", Weight: 10},
+			{ServiceName: "exp-svc-2", Weight: 10},
+		},
+	}
+	httpRoute := experimentHTTPRoute(
+		backendRef("stable-svc", 60),
+		backendRef("canary-svc", 40),
+		backendRef("exp-svc-1", 10),
+		backendRef("unmanaged-svc", 5),
+		backendRef("exp-svc-2", 10),
+	)
+
+	err := HandleExperiment(context.Background(), nil, nil, testLogger(), rollout, httpRoute, nil)
+
+	require.NoError(t, err)
+	require.Len(t, httpRoute.Spec.Rules[0].BackendRefs, 3)
+	assert.Equal(t, gatewayv1.ObjectName("stable-svc"), httpRoute.Spec.Rules[0].BackendRefs[0].Name)
+	assert.Equal(t, int32(100), *httpRoute.Spec.Rules[0].BackendRefs[0].Weight)
+	assert.Equal(t, gatewayv1.ObjectName("canary-svc"), httpRoute.Spec.Rules[0].BackendRefs[1].Name)
+	assert.Equal(t, int32(0), *httpRoute.Spec.Rules[0].BackendRefs[1].Weight)
+	assert.Equal(t, gatewayv1.ObjectName("unmanaged-svc"), httpRoute.Spec.Rules[0].BackendRefs[2].Name)
+}
+
 func experimentRollout(maxWeight int32, currentExperiment string) *v1alpha1.Rollout {
 	return &v1alpha1.Rollout{
 		ObjectMeta: metav1.ObjectMeta{Name: "rollout-test", Namespace: "default"},

--- a/pkg/plugin/experiment_test.go
+++ b/pkg/plugin/experiment_test.go
@@ -247,6 +247,30 @@ func TestHandleExperimentUsesMaxTrafficWeight(t *testing.T) {
 	assert.Equal(t, int32(50000), *httpRoute.Spec.Rules[0].BackendRefs[0].Weight)
 }
 
+func TestHandleExperimentPreservesCanaryWeight(t *testing.T) {
+	const maxWeight = int32(100)
+	rollout := experimentRollout(maxWeight, "active-experiment")
+	httpRoute := experimentHTTPRoute(
+		backendRef("stable-svc", 80),
+		backendRef("canary-svc", 20),
+		backendRef("exp-svc-1", 10),
+		backendRef("exp-svc-2", 10),
+	)
+	destinations := []v1alpha1.WeightDestination{
+		{ServiceName: "exp-svc-1", Weight: 10},
+		{ServiceName: "exp-svc-2", Weight: 10},
+	}
+
+	err := HandleExperiment(context.Background(), nil, nil, testLogger(), rollout, httpRoute, destinations)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(60), *httpRoute.Spec.Rules[0].BackendRefs[0].Weight)
+	assert.Equal(t, int32(20), *httpRoute.Spec.Rules[0].BackendRefs[1].Weight)
+	assert.Equal(t, int32(10), *httpRoute.Spec.Rules[0].BackendRefs[2].Weight)
+	assert.Equal(t, int32(10), *httpRoute.Spec.Rules[0].BackendRefs[3].Weight)
+	assert.Equal(t, "exp-svc-1,exp-svc-2", httpRoute.Annotations[experimentServicesAnnotation])
+}
+
 func TestHandleExperimentFloorsStableWeightWhenExperimentWeightsExceedMaxTrafficWeight(t *testing.T) {
 	const maxWeight = int32(100000)
 	rollout := experimentRollout(maxWeight, "active-experiment")
@@ -289,6 +313,29 @@ func TestHandleExperimentCleanupRestoresMaxTrafficWeight(t *testing.T) {
 	require.Len(t, httpRoute.Spec.Rules[0].BackendRefs, 2)
 	assert.Equal(t, int32(100000), *httpRoute.Spec.Rules[0].BackendRefs[0].Weight)
 	assert.Equal(t, int32(0), *httpRoute.Spec.Rules[0].BackendRefs[1].Weight)
+}
+
+func TestHandleExperimentCleanupUsesRouteOwnershipAfterRolloutStatusIsCleared(t *testing.T) {
+	rollout := experimentRollout(100, "")
+	httpRoute := experimentHTTPRoute(
+		backendRef("stable-svc", 100),
+		backendRef("canary-svc", 0),
+		backendRef("exp-svc-1", 10),
+		backendRef("unmanaged-svc", 5),
+		backendRef("exp-svc-2", 10),
+	)
+	httpRoute.Annotations = map[string]string{
+		experimentServicesAnnotation: "exp-svc-1,exp-svc-2",
+	}
+
+	err := HandleExperiment(context.Background(), nil, nil, testLogger(), rollout, httpRoute, nil)
+
+	require.NoError(t, err)
+	require.Len(t, httpRoute.Spec.Rules[0].BackendRefs, 3)
+	assert.Equal(t, gatewayv1.ObjectName("stable-svc"), httpRoute.Spec.Rules[0].BackendRefs[0].Name)
+	assert.Equal(t, gatewayv1.ObjectName("canary-svc"), httpRoute.Spec.Rules[0].BackendRefs[1].Name)
+	assert.Equal(t, gatewayv1.ObjectName("unmanaged-svc"), httpRoute.Spec.Rules[0].BackendRefs[2].Name)
+	assert.NotContains(t, httpRoute.Annotations, experimentServicesAnnotation)
 }
 
 func experimentRollout(maxWeight int32, currentExperiment string) *v1alpha1.Rollout {

--- a/test/e2e/chainsaw/httproute-canary-experiment/assertions/httproute-after-cleanup.yaml
+++ b/test/e2e/chainsaw/httproute-canary-experiment/assertions/httproute-after-cleanup.yaml
@@ -6,9 +6,5 @@ metadata:
 spec:
   (length(rules)): 1
   rules:
-    - (length(backendRefs)): 2
-      backendRefs:
-        - name: httproute-canary-experiment-stable-service
-          (weight): 100
-        - name: httproute-canary-experiment-canary-service
-          (weight): 0
+    - (length(backendRefs[?name == 'httproute-canary-experiment-stable-service' && weight == `100`])): 1
+      (length(backendRefs[?name == 'httproute-canary-experiment-canary-service' && weight == `0`])): 1

--- a/test/e2e/chainsaw/httproute-canary-experiment/assertions/httproute-after-cleanup.yaml
+++ b/test/e2e/chainsaw/httproute-canary-experiment/assertions/httproute-after-cleanup.yaml
@@ -6,5 +6,9 @@ metadata:
 spec:
   (length(rules)): 1
   rules:
-    - (length(backendRefs[?name == 'httproute-canary-experiment-stable-service' && weight == `100`])): 1
-      (length(backendRefs[?name == 'httproute-canary-experiment-canary-service' && weight == `0`])): 1
+    - (length(backendRefs)): 2
+      backendRefs:
+        - name: httproute-canary-experiment-stable-service
+          (weight): 100
+        - name: httproute-canary-experiment-canary-service
+          (weight): 0

--- a/test/e2e/chainsaw/httproute-canary-experiment/assertions/httproute-after-cleanup.yaml
+++ b/test/e2e/chainsaw/httproute-canary-experiment/assertions/httproute-after-cleanup.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-canary-experiment
+  namespace: default
+spec:
+  (length(rules)): 1
+  rules:
+    - (length(backendRefs)): 2
+      backendRefs:
+        - name: httproute-canary-experiment-stable-service
+          (weight): 100
+        - name: httproute-canary-experiment-canary-service
+          (weight): 0

--- a/test/e2e/chainsaw/httproute-canary-experiment/assertions/httproute-experiment.yaml
+++ b/test/e2e/chainsaw/httproute-canary-experiment/assertions/httproute-experiment.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-canary-experiment
+  namespace: default
+spec:
+  (length(rules)): 1
+  rules:
+    - (length(backendRefs)): 4
+      backendRefs:
+        - name: httproute-canary-experiment-stable-service
+          (weight): 60
+        - name: httproute-canary-experiment-canary-service
+          (weight): 20
+        - name: httproute-canary-experiment-baseline-service
+          (weight): 10
+        - name: httproute-canary-experiment-candidate-service
+          (weight): 10

--- a/test/e2e/chainsaw/httproute-canary-experiment/assertions/httproute-initial.yaml
+++ b/test/e2e/chainsaw/httproute-canary-experiment/assertions/httproute-initial.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-canary-experiment
+  namespace: default
+spec:
+  (length(rules)): 1
+  rules:
+    - (length(backendRefs)): 2
+      backendRefs:
+        - name: httproute-canary-experiment-stable-service
+          (weight): 100
+        - name: httproute-canary-experiment-canary-service
+          (weight): 0

--- a/test/e2e/chainsaw/httproute-canary-experiment/assertions/rollout-healthy.yaml
+++ b/test/e2e/chainsaw/httproute-canary-experiment/assertions/rollout-healthy.yaml
@@ -1,0 +1,7 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: httproute-canary-experiment-rollout
+  namespace: default
+status:
+  (phase == 'Healthy'): true

--- a/test/e2e/chainsaw/httproute-canary-experiment/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/httproute-canary-experiment/chainsaw-test.yaml
@@ -99,7 +99,7 @@ spec:
             file: assertions/rollout-healthy.yaml
 
     - name: assert-cleanup
-      description: Plugin resets stable and canary weights after promotion.
+      description: Plugin removes experiment backends and resets canary weight to 0 after promotion.
       try:
         - assert:
             timeout: 60s

--- a/test/e2e/chainsaw/httproute-canary-experiment/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/httproute-canary-experiment/chainsaw-test.yaml
@@ -99,7 +99,7 @@ spec:
             file: assertions/rollout-healthy.yaml
 
     - name: assert-cleanup
-      description: Plugin removes experiment backends and resets canary weight to 0 after promotion.
+      description: Plugin resets stable and canary weights after promotion.
       try:
         - assert:
             timeout: 60s

--- a/test/e2e/chainsaw/httproute-canary-experiment/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/httproute-canary-experiment/chainsaw-test.yaml
@@ -1,0 +1,106 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: httproute-canary-experiment
+  labels:
+    route-type: http
+spec:
+  description: >
+    Verifies that combining canary and experiment works correctly, in particular
+    the weight calculation should be correct.
+  # Uses 'default' namespace so the gateway (traefik-gateway) is accessible.
+  namespace: default
+  concurrent: true
+
+  steps:
+    - name: cleanup-previous-run
+      description: Remove resources left behind by an interrupted or skip-delete run.
+      try:
+        - delete:
+            file: resources/rollout.yaml
+            deletionPropagationPolicy: Foreground
+        - delete:
+            file: resources/httproute.yaml
+        - delete:
+            file: resources/services.yaml
+
+    - name: create-resources
+      description: Create the Services, HTTPRoute, and Rollout.
+      try:
+        - apply:
+            file: resources/services.yaml
+        - apply:
+            file: resources/httproute.yaml
+        - apply:
+            file: resources/rollout.yaml
+
+    - name: assert-initial-state
+      description: Plugin initializes the HTTPRoute with stable weight 100 and canary weight 0.
+      try:
+        - assert:
+            timeout: 30s
+            file: assertions/httproute-initial.yaml
+
+    - name: wait-for-initial-healthy
+      description: Wait for the initial rollout to reach Healthy before triggering a canary.
+      try:
+        - assert:
+            timeout: 5m
+            file: assertions/rollout-healthy.yaml
+
+    - name: trigger-canary
+      description: Trigger canary, set canary weight to 20 and create two experiments with weight 10 each.
+      try:
+        - patch:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Rollout
+              metadata:
+                name: httproute-canary-experiment-rollout
+                namespace: default
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: rollouts-demo
+                        image: argoproj/rollouts-demo:green
+                        ports:
+                          - name: http
+                            containerPort: 8080
+                            protocol: TCP
+
+    - name: assert-canary-and-experiment-weights
+      description: Stable should have weight 60, canary should have weight 20, and the experiments should each have weight 10.
+      try:
+        - assert:
+            timeout: 3m
+            file: assertions/httproute-experiment.yaml
+
+    - name: promote-experiment-step
+      description: Promote the rollout.
+      try:
+        - patch:
+            subresource: status
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Rollout
+              metadata:
+                name: httproute-canary-experiment-rollout
+                namespace: default
+              status:
+                pauseConditions: null
+                currentStepIndex: 2
+
+    - name: assert-rollout-healthy
+      description: Wait for the promotion to complete and the rollout to become Healthy.
+      try:
+        - assert:
+            timeout: 5m
+            file: assertions/rollout-healthy.yaml
+
+    - name: assert-cleanup
+      description: Plugin removes experiment backends and resets canary weight to 0 after promotion.
+      try:
+        - assert:
+            timeout: 60s
+            file: assertions/httproute-after-cleanup.yaml

--- a/test/e2e/chainsaw/httproute-canary-experiment/resources/httproute.yaml
+++ b/test/e2e/chainsaw/httproute-canary-experiment/resources/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httproute-canary-experiment
+  namespace: default
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      namespace: default
+  rules:
+    - backendRefs:
+        - name: httproute-canary-experiment-stable-service
+          port: 80
+        - name: httproute-canary-experiment-canary-service
+          port: 80

--- a/test/e2e/chainsaw/httproute-canary-experiment/resources/rollout.yaml
+++ b/test/e2e/chainsaw/httproute-canary-experiment/resources/rollout.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: httproute-canary-experiment-rollout
+  namespace: default
+spec:
+  replicas: 2
+  strategy:
+    canary:
+      canaryService: httproute-canary-experiment-canary-service
+      stableService: httproute-canary-experiment-stable-service
+      trafficRouting:
+        plugins:
+          argoproj-labs/gatewayAPI:
+            httpRoute: httproute-canary-experiment
+            namespace: default
+      steps:
+        - setWeight: 20
+        - experiment:
+            templates:
+              - name: baseline
+                specRef: stable
+                replicas: 1
+                weight: 10
+                service:
+                  name: httproute-canary-experiment-baseline-service
+              - name: candidate
+                specRef: canary
+                replicas: 1
+                weight: 10
+                service:
+                  name: httproute-canary-experiment-candidate-service
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: httproute-canary-experiment
+  template:
+    metadata:
+      labels:
+        app: httproute-canary-experiment
+    spec:
+      containers:
+        - name: rollouts-demo
+          image: argoproj/rollouts-demo:red
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP

--- a/test/e2e/chainsaw/httproute-canary-experiment/resources/services.yaml
+++ b/test/e2e/chainsaw/httproute-canary-experiment/resources/services.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: httproute-canary-experiment-stable-service
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: httproute-canary-experiment
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httproute-canary-experiment-canary-service
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: httproute-canary-experiment


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Description of this PR

This PR fixes the calculation of experiment weight when both canary and experiment are in use.

Also updates Chainsaw to the v0.2.15 (newest version) so subresource patching can be used.

## Checklist:

* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] My build is green.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged
* [x] The tests actually define testcases about the feature/fix implemented
* [x] I have run all tests locally and they pass
* [x] I haven't changed the existing tests in a significant way, as this will break functionality for existing users <sup>1</sup>
* [x] I've updated documentation as required by this PR.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY it works that way according to my use case
* [x] I understand what the code does and HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My new code is using existing utility functions instead of re-implementing everything again
* [ ] Optional. My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md)

Notes

1. Unless a discussion has happened already in an issue and the breaking change is deemed acceptable
