### PR TITLE
feat: add ruleName option to scope traffic weighting to a single rule

### DIFF
--- a/docs/features/rule-scoped-weighting.md
+++ b/docs/features/rule-scoped-weighting.md
@@ -1,0 +1,137 @@
+# Rule-Scoped Weighting
+
+By default, the plugin manages **every rule** on a route that contains both the configured
+`canaryService` and `stableService` BackendRefs — it identifies "its" rule purely by those two
+backend names. On a route with a single rule this is exactly what you want, but it means two
+rules that both happen to reference `canaryService`/`stableService` will *both* get their
+weights rewritten on every reconcile, even if only one of them is meant to carry live traffic.
+
+`ruleName` lets you pin the plugin to a single rule, identified by the rule's own
+[Gateway API `name`](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteRule) field, so it never touches any other rule — regardless of what backend
+names that other rule contains.
+
+## When you need this
+
+A common case: you want a rule that's actually live and carries the canary/stable split
+*plus* a third, unrelated static backend — for example a fixed 5% side-tap to a discovery
+service alongside your canary/stable traffic. You also want a second rule, sharing the same
+`stable`/`canary` names, that exists purely so the plugin has a clean pair of weights to write
+to on every step. An external controller you run watches that second rule and recomputes the
+live rule's three weights (rescaled to fit the reserved percentage) whenever it changes.
+
+Without `ruleName`, the plugin can't tell these two rules apart — it finds `stable`+`canary` in
+both and overwrites both, clobbering your rescaled live weights on every reconcile. With
+`ruleName` set to the second rule's name, the plugin only ever touches that one.
+
+```yaml
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+metadata:
+  name: test
+  namespace: default
+spec:
+  parentRefs:
+    - name: default-gateway
+  hostnames:
+    - test.example.com
+  rules:
+    # The live rule: actually receives traffic. The plugin never touches this rule directly;
+    # an external controller keeps it in sync with the "argo" rule below.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: discovery
+          kind: Service
+          port: 80
+          weight: 5
+        - name: stable
+          kind: Service
+          port: 80
+          weight: 95
+        - name: canary
+          kind: Service
+          port: 80
+          weight: 0
+    # The "argo" rule: unreachable (identical match to the rule above, so it never wins
+    # precedence), but this is the only rule the plugin is configured to manage.
+    - name: argo
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: stable
+          kind: Service
+          port: 80
+          weight: 100
+        - name: canary
+          kind: Service
+          port: 80
+          weight: 0
+```
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: rollouts-demo
+  namespace: default
+spec:
+  strategy:
+    canary:
+      canaryService: canary
+      stableService: stable
+      trafficRouting:
+        plugins:
+          argoproj-labs/gatewayAPI:
+            httpRoute: test
+            httpRouteRuleName: argo
+            namespace: default
+      steps:
+        - setWeight: 10
+        - pause: {}
+        - setWeight: 50
+        - pause: {}
+        - setWeight: 100
+        - pause: {}
+  # ... rest of rollout spec
+```
+
+The plugin only ever reads and writes the `argo` rule. Reconciling the live rule's weights from
+`argo`'s weights (rescaled to account for the reserved 5%) is your controller's job — this
+option only guarantees the plugin won't touch the wrong rule; it doesn't perform that
+normalization itself.
+
+!!! tip
+    If all you need is a fixed reserved percentage for a side backend — and you don't need a
+    second, externally-reconciled rule at all — consider
+    [`trafficRouting.maxTrafficWeight`](https://argo-rollouts.readthedocs.io/en/stable/features/traffic-management/)
+    on the Rollout instead. Setting it to `100 - <reserved>` makes the canary/stable weights the
+    plugin writes always sum to exactly that reserved amount, with no second rule or external
+    controller required.
+
+## Configuration reference
+
+`ruleName` is available on every route kind, both in the list form and as a sibling to the
+singular form:
+
+| Config field | Applies to |
+|---|---|
+| `httpRoute` + `httpRouteRuleName` | Singular HTTPRoute |
+| `httpRoutes[].ruleName` | Each entry under the `httpRoutes` list |
+| `grpcRoute` + `grpcRouteRuleName` | Singular GRPCRoute |
+| `grpcRoutes[].ruleName` | Each entry under the `grpcRoutes` list |
+| `tcpRoute` + `tcpRouteRuleName` | Singular TCPRoute |
+| `tcpRoutes[].ruleName` | Each entry under the `tcpRoutes` list |
+| `tlsRoute` + `tlsRouteRuleName` | Singular TLSRoute |
+| `tlsRoutes[].ruleName` | Each entry under the `tlsRoutes` list |
+
+If `ruleName` is set but no rule with that name contains both the canary and stable BackendRefs
+(HTTPRoute/GRPCRoute), or exists at all (TCPRoute/TLSRoute), `SetWeight`/`SetHeaderRoute` return
+an error rather than silently matching nothing.
+
+If `ruleName` is left unset, behavior is unchanged from previous versions of the plugin: every
+rule containing both backend names is managed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,8 @@ nav:
 - Features: 
   - Advanced Deployments: features/advanced-deployments.md
   - Multiple Routes: features/multiple-routes.md
-  - Header Based Routing: features/header-based-routing.md    
+  - Header Based Routing: features/header-based-routing.md
+  - Rule-Scoped Weighting: features/rule-scoped-weighting.md
   - TCP Routing: features/tcp.md
   - TLS Routing: features/tls.md
   - GRPC Routing: features/grpc.md  

--- a/pkg/plugin/errors.go
+++ b/pkg/plugin/errors.go
@@ -10,4 +10,8 @@ const (
 	BackendRefWasNotFoundInTLSRouteError     = "backendRef was not found in tlsRoute"
 	BackendRefListWasNotFoundInTCPRouteError = "backendRef list was not found in tcpRoute"
 	BackendRefListWasNotFoundInTLSRouteError = "backendRef list was not found in tlsRoute"
+	RuleNameNotFoundInHTTPRouteError         = "the configured ruleName was not found among rules containing the canary and stable backendRefs in httpRoute"
+	RuleNameNotFoundInGRPCRouteError         = "the configured ruleName was not found among rules containing the canary and stable backendRefs in grpcRoute"
+	RuleNameNotFoundInTCPRouteError          = "the configured ruleName was not found among the rules in tcpRoute"
+	RuleNameNotFoundInTLSRouteError          = "the configured ruleName was not found among the rules in tlsRoute"
 )

--- a/pkg/plugin/grpcroute.go
+++ b/pkg/plugin/grpcroute.go
@@ -35,6 +35,10 @@ func (r *RpcPlugin) setGRPCRouteWeight(rollout *v1alpha1.Rollout, desiredWeight 
 		if err != nil {
 			return err
 		}
+		weightedRules = filterRulesByName(weightedRules, gatewayAPIConfig.GRPCRouteRuleName)
+		if len(weightedRules) == 0 {
+			return errors.New(RuleNameNotFoundInGRPCRouteError)
+		}
 		for _, rule := range weightedRules {
 			for j := range rule.BackendRefs {
 				switch string(rule.BackendRefs[j].Name) {
@@ -88,6 +92,10 @@ func (r *RpcPlugin) setGRPCHeaderRoute(rollout *v1alpha1.Rollout, headerRouting 
 		sourceRules, err := getAllRouteRules(grpcRouteRuleList, backendRefNameList...)
 		if err != nil {
 			return err
+		}
+		sourceRules = filterRulesByName(sourceRules, gatewayAPIConfig.GRPCRouteRuleName)
+		if len(sourceRules) == 0 {
+			return errors.New(RuleNameNotFoundInGRPCRouteError)
 		}
 
 		// Build one managed header rule per source rule so that the canary header
@@ -278,6 +286,13 @@ func (r GRPCRouteRuleList) Iterator() (GatewayAPIRouteRuleListIterator[*GRPCBack
 
 func (r GRPCRouteRuleList) Error() error {
 	return errors.New(BackendRefWasNotFoundInGRPCRouteError)
+}
+
+func (r *GRPCRouteRule) GetRuleName() string {
+	if r.Name == nil {
+		return ""
+	}
+	return string(*r.Name)
 }
 
 func (r *GRPCBackendRef) GetName() string {

--- a/pkg/plugin/httproute.go
+++ b/pkg/plugin/httproute.go
@@ -35,6 +35,10 @@ func (r *RpcPlugin) setHTTPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight 
 		if err != nil {
 			return err
 		}
+		weightedRules = filterRulesByName(weightedRules, gatewayAPIConfig.HTTPRouteRuleName)
+		if len(weightedRules) == 0 {
+			return errors.New(RuleNameNotFoundInHTTPRouteError)
+		}
 		for _, rule := range weightedRules {
 			for j := range rule.BackendRefs {
 				switch string(rule.BackendRefs[j].Name) {
@@ -93,6 +97,10 @@ func (r *RpcPlugin) setHTTPHeaderRoute(rollout *v1alpha1.Rollout, headerRouting 
 		sourceRules, err := getAllRouteRules(httpRouteRuleList, backendRefNameList...)
 		if err != nil {
 			return err
+		}
+		sourceRules = filterRulesByName(sourceRules, gatewayAPIConfig.HTTPRouteRuleName)
+		if len(sourceRules) == 0 {
+			return errors.New(RuleNameNotFoundInHTTPRouteError)
 		}
 
 		// Build one managed header rule per source rule so that the canary header
@@ -285,6 +293,13 @@ func (r HTTPRouteRuleList) Iterator() (GatewayAPIRouteRuleListIterator[*HTTPBack
 
 func (r HTTPRouteRuleList) Error() error {
 	return errors.New(BackendRefWasNotFoundInHTTPRouteError)
+}
+
+func (r *HTTPRouteRule) GetRuleName() string {
+	if r.Name == nil {
+		return ""
+	}
+	return string(*r.Name)
 }
 
 func (r *HTTPBackendRef) GetName() string {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -80,6 +80,7 @@ func (r *RpcPlugin) SetWeight(rollout *v1alpha1.Rollout, desiredWeight int32, ad
 		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls HTTPRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.HTTPRoutes)))
 		rpcError = forEachGatewayAPIRoute(gatewayAPIConfig.HTTPRoutes, func(route HTTPRoute) pluginTypes.RpcError {
 			gatewayAPIConfig.HTTPRoute = route.Name
+			gatewayAPIConfig.HTTPRouteRuleName = route.RuleName
 			return r.setHTTPRouteWeight(rollout, desiredWeight, additionalDestinations, gatewayAPIConfig)
 		})
 		if rpcError.HasError() {
@@ -90,6 +91,7 @@ func (r *RpcPlugin) SetWeight(rollout *v1alpha1.Rollout, desiredWeight int32, ad
 		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls GRPCRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.GRPCRoutes)))
 		rpcError = forEachGatewayAPIRoute(gatewayAPIConfig.GRPCRoutes, func(route GRPCRoute) pluginTypes.RpcError {
 			gatewayAPIConfig.GRPCRoute = route.Name
+			gatewayAPIConfig.GRPCRouteRuleName = route.RuleName
 			return r.setGRPCRouteWeight(rollout, desiredWeight, gatewayAPIConfig)
 		})
 		if rpcError.HasError() {
@@ -100,6 +102,7 @@ func (r *RpcPlugin) SetWeight(rollout *v1alpha1.Rollout, desiredWeight int32, ad
 		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls TCPRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.TCPRoutes)))
 		rpcError = forEachGatewayAPIRoute(gatewayAPIConfig.TCPRoutes, func(route TCPRoute) pluginTypes.RpcError {
 			gatewayAPIConfig.TCPRoute = route.Name
+			gatewayAPIConfig.TCPRouteRuleName = route.RuleName
 			return r.setTCPRouteWeight(rollout, desiredWeight, gatewayAPIConfig)
 		})
 		if rpcError.HasError() {
@@ -110,6 +113,7 @@ func (r *RpcPlugin) SetWeight(rollout *v1alpha1.Rollout, desiredWeight int32, ad
 		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls TLSRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.TLSRoutes)))
 		rpcError = forEachGatewayAPIRoute(gatewayAPIConfig.TLSRoutes, func(route TLSRoute) pluginTypes.RpcError {
 			gatewayAPIConfig.TLSRoute = route.Name
+			gatewayAPIConfig.TLSRouteRuleName = route.RuleName
 			return r.setTLSRouteWeight(rollout, desiredWeight, gatewayAPIConfig)
 		})
 	}
@@ -130,6 +134,7 @@ func (r *RpcPlugin) SetHeaderRoute(rollout *v1alpha1.Rollout, headerRouting *v1a
 				return pluginTypes.RpcError{}
 			}
 			gatewayAPIConfig.HTTPRoute = route.Name
+			gatewayAPIConfig.HTTPRouteRuleName = route.RuleName
 			return r.setHTTPHeaderRoute(rollout, headerRouting, gatewayAPIConfig)
 		})
 		if rpcError.HasError() {
@@ -143,6 +148,7 @@ func (r *RpcPlugin) SetHeaderRoute(rollout *v1alpha1.Rollout, headerRouting *v1a
 				return pluginTypes.RpcError{}
 			}
 			gatewayAPIConfig.GRPCRoute = route.Name
+			gatewayAPIConfig.GRPCRouteRuleName = route.RuleName
 			return r.setGRPCHeaderRoute(rollout, headerRouting, gatewayAPIConfig)
 		})
 		if rpcError.HasError() {
@@ -352,24 +358,28 @@ func insertGatewayAPIRouteLists(gatewayAPIConfig *GatewayAPITrafficRouting) {
 		gatewayAPIConfig.HTTPRoutes = append(gatewayAPIConfig.HTTPRoutes, HTTPRoute{
 			Name:            gatewayAPIConfig.HTTPRoute,
 			UseHeaderRoutes: true,
+			RuleName:        gatewayAPIConfig.HTTPRouteRuleName,
 		})
 	}
 	if gatewayAPIConfig.GRPCRoute != "" {
 		gatewayAPIConfig.GRPCRoutes = append(gatewayAPIConfig.GRPCRoutes, GRPCRoute{
 			Name:            gatewayAPIConfig.GRPCRoute,
 			UseHeaderRoutes: true,
+			RuleName:        gatewayAPIConfig.GRPCRouteRuleName,
 		})
 	}
 	if gatewayAPIConfig.TCPRoute != "" {
 		gatewayAPIConfig.TCPRoutes = append(gatewayAPIConfig.TCPRoutes, TCPRoute{
 			Name:            gatewayAPIConfig.TCPRoute,
 			UseHeaderRoutes: true,
+			RuleName:        gatewayAPIConfig.TCPRouteRuleName,
 		})
 	}
 	if gatewayAPIConfig.TLSRoute != "" {
 		gatewayAPIConfig.TLSRoutes = append(gatewayAPIConfig.TLSRoutes, TLSRoute{
 			Name:            gatewayAPIConfig.TLSRoute,
 			UseHeaderRoutes: true,
+			RuleName:        gatewayAPIConfig.TLSRouteRuleName,
 		})
 	}
 }
@@ -458,6 +468,22 @@ func getAllRouteRules[BackendRef GatewayAPIBackendRef, RouteRule GatewayAPIRoute
 		return nil, routeRuleList.Error()
 	}
 	return result, nil
+}
+
+// filterRulesByName restricts rules to the one with the given Gateway API rule Name. An
+// empty ruleName is a no-op, returning rules unchanged, so routes with a single managed
+// rule (the common case) are unaffected.
+func filterRulesByName[T1 GatewayAPIBackendRef, T2 GatewayAPIRouteRule[T1]](rules []T2, ruleName string) []T2 {
+	if ruleName == "" {
+		return rules
+	}
+	filtered := make([]T2, 0, len(rules))
+	for _, rule := range rules {
+		if rule.GetRuleName() == ruleName {
+			filtered = append(filtered, rule)
+		}
+	}
+	return filtered
 }
 
 func getBackendRefs[T1 GatewayAPIBackendRef, T2 GatewayAPIRouteRule[T1], T3 GatewayAPIRouteRuleList[T1, T2]](backendRefName string, routeRuleList T3) ([]T1, error) {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -18,6 +18,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwFake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 
 	goPlugin "github.com/hashicorp/go-plugin"
@@ -2512,4 +2513,342 @@ func TestSetHTTPHeaderRouteSameHeaderNameDifferentValuesCoexist(t *testing.T) {
 	require.Len(t, route2.Matches, 1)
 	require.Len(t, route2.Matches[0].Headers, 1)
 	assert.Equal(t, "internal", route2.Matches[0].Headers[0].Value)
+}
+
+// TestSetWeightWithRuleNameOnlyUpdatesNamedRule covers the motivating case for the ruleName
+// option: an HTTPRoute has a "live" rule that carries the canary/stable split plus a third,
+// unrelated static backend (e.g. a fixed 5% side-tap to a discovery service), and a second,
+// otherwise-unreachable "argo" rule that shares the same stable/canary backend names purely so
+// the plugin has a rule it can freely rewrite. Without ruleName both rules would be matched and
+// rewritten by getAllRouteRules; with ruleName set, only the named rule may change.
+func TestSetWeightWithRuleNameOnlyUpdatesNamedRule(t *testing.T) {
+	httpRoute := mocks.CreateHTTPRouteWithLabels(mocks.HTTPRouteName, nil)
+
+	discoveryPort := gatewayv1.PortNumber(80)
+	discoveryWeight := int32(5)
+	httpRoute.Spec.Rules[0].BackendRefs = append(httpRoute.Spec.Rules[0].BackendRefs, gatewayv1.HTTPBackendRef{
+		BackendRef: gatewayv1.BackendRef{
+			BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name: "discovery-service",
+				Port: &discoveryPort,
+			},
+			Weight: &discoveryWeight,
+		},
+	})
+
+	argoRuleName := gatewayv1.SectionName("argo")
+	argoPort := gatewayv1.PortNumber(80)
+	argoStableWeight := int32(100)
+	argoCanaryWeight := int32(0)
+	httpRoute.Spec.Rules = append(httpRoute.Spec.Rules, gatewayv1.HTTPRouteRule{
+		Name: &argoRuleName,
+		BackendRefs: []gatewayv1.HTTPBackendRef{
+			{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: mocks.StableServiceName,
+						Port: &argoPort,
+					},
+					Weight: &argoStableWeight,
+				},
+			},
+			{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: mocks.CanaryServiceName,
+						Port: &argoPort,
+					},
+					Weight: &argoCanaryWeight,
+				},
+			},
+		},
+	})
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+		Namespace:         mocks.RolloutNamespace,
+		HTTPRoute:         mocks.HTTPRouteName,
+		HTTPRouteRuleName: "argo",
+	})
+
+	err := rpcPluginImp.SetWeight(rollout, 30, []v1alpha1.WeightDestination{})
+	assert.Empty(t, err.Error())
+
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+	require.Len(t, updatedHTTP.Spec.Rules, 2)
+
+	liveRule := updatedHTTP.Spec.Rules[0]
+	require.Len(t, liveRule.BackendRefs, 3, "the live rule's backends must not be added to or removed")
+	assert.Equal(t, int32(100), *liveRule.BackendRefs[0].Weight, "ruleName must protect the live rule's stable weight")
+	assert.Equal(t, int32(0), *liveRule.BackendRefs[1].Weight, "ruleName must protect the live rule's canary weight")
+	assert.Equal(t, int32(5), *liveRule.BackendRefs[2].Weight, "ruleName must protect the live rule's discovery weight")
+
+	argoRule := updatedHTTP.Spec.Rules[1]
+	require.NotNil(t, argoRule.Name)
+	assert.Equal(t, "argo", string(*argoRule.Name))
+	assert.Equal(t, int32(70), *argoRule.BackendRefs[0].Weight, "the named rule's stable weight must be updated")
+	assert.Equal(t, int32(30), *argoRule.BackendRefs[1].Weight, "the named rule's canary weight must be updated")
+}
+
+// TestSetWeightRuleNameNotFoundReturnsError covers the list ("httpRoutes") config form and
+// verifies that a ruleName which matches no rule containing both the canary and stable
+// BackendRefs surfaces a clear error rather than silently doing nothing.
+func TestSetWeightRuleNameNotFoundReturnsError(t *testing.T) {
+	httpRoute := mocks.CreateHTTPRouteWithLabels(mocks.HTTPRouteName, nil)
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+		Namespace: mocks.RolloutNamespace,
+		HTTPRoutes: []HTTPRoute{
+			{Name: mocks.HTTPRouteName, RuleName: "does-not-exist"},
+		},
+	})
+
+	err := rpcPluginImp.SetWeight(rollout, 30, []v1alpha1.WeightDestination{})
+	assert.Equal(t, RuleNameNotFoundInHTTPRouteError, err.ErrorString)
+}
+
+// TestSetHTTPHeaderRouteWithRuleNameUsesOnlyNamedSourceRule verifies that header-route rules
+// are generated only from the pinned rule when multiple rules contain the canary/stable
+// BackendRefs, mirroring the SetWeight guarantee for the SetHeaderRoute path.
+func TestSetHTTPHeaderRouteWithRuleNameUsesOnlyNamedSourceRule(t *testing.T) {
+	httpRoute := mocks.CreateHTTPRouteWithLabels(mocks.HTTPRouteName, nil)
+
+	argoRuleName := gatewayv1.SectionName("argo")
+	argoPort := gatewayv1.PortNumber(80)
+	argoStableWeight := int32(100)
+	argoCanaryWeight := int32(0)
+	httpRoute.Spec.Rules = append(httpRoute.Spec.Rules, gatewayv1.HTTPRouteRule{
+		Name: &argoRuleName,
+		BackendRefs: []gatewayv1.HTTPBackendRef{
+			{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: mocks.StableServiceName,
+						Port: &argoPort,
+					},
+					Weight: &argoStableWeight,
+				},
+			},
+			{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: mocks.CanaryServiceName,
+						Port: &argoPort,
+					},
+					Weight: &argoCanaryWeight,
+				},
+			},
+		},
+	})
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+		Namespace:         mocks.RolloutNamespace,
+		HTTPRoute:         mocks.HTTPRouteName,
+		HTTPRouteRuleName: "argo",
+	})
+
+	headerRouting := v1alpha1.SetHeaderRoute{
+		Name: "canary-header",
+		Match: []v1alpha1.HeaderRoutingMatch{
+			{HeaderName: "user-group", HeaderValue: &v1alpha1.StringMatch{Exact: "internal"}},
+		},
+	}
+
+	err := rpcPluginImp.SetHeaderRoute(rollout, &headerRouting)
+	assert.Empty(t, err.Error())
+
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+	// original unnamed rule + "argo" rule + exactly one generated header rule
+	require.Len(t, updatedHTTP.Spec.Rules, 3, "only one header rule must be generated, from the named source rule")
+
+	var headerRule *gatewayv1.HTTPRouteRule
+	for i := range updatedHTTP.Spec.Rules {
+		if updatedHTTP.Spec.Rules[i].Name != nil && string(*updatedHTTP.Spec.Rules[i].Name) == "canary-header" {
+			headerRule = &updatedHTTP.Spec.Rules[i]
+		}
+	}
+	require.NotNil(t, headerRule, "canary-header rule must have been generated from the argo rule")
+}
+
+// TestSetGRPCRouteWeightWithRuleName mirrors TestSetWeightWithRuleNameOnlyUpdatesNamedRule for
+// GRPCRoute: two rules share the stable/canary BackendRefs, and ruleName must restrict weight
+// changes to the named one.
+func TestSetGRPCRouteWeightWithRuleName(t *testing.T) {
+	grpcRoute := mocks.CreateGRPCRouteWithLabels(mocks.GRPCRouteName, nil)
+
+	argoRuleName := gatewayv1.SectionName("argo")
+	argoPort := gatewayv1.PortNumber(80)
+	argoStableWeight := int32(100)
+	argoCanaryWeight := int32(0)
+	grpcRoute.Spec.Rules = append(grpcRoute.Spec.Rules, gatewayv1.GRPCRouteRule{
+		Name: &argoRuleName,
+		BackendRefs: []gatewayv1.GRPCBackendRef{
+			{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: mocks.StableServiceName,
+						Port: &argoPort,
+					},
+					Weight: &argoStableWeight,
+				},
+			},
+			{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: mocks.CanaryServiceName,
+						Port: &argoPort,
+					},
+					Weight: &argoCanaryWeight,
+				},
+			},
+		},
+	})
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(grpcRoute),
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+		Namespace:         mocks.RolloutNamespace,
+		GRPCRoute:         mocks.GRPCRouteName,
+		GRPCRouteRuleName: "argo",
+	})
+
+	err := rpcPluginImp.SetWeight(rollout, 40, []v1alpha1.WeightDestination{})
+	assert.Empty(t, err.Error())
+
+	updatedGRPC, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().GRPCRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.GRPCRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+	require.Len(t, updatedGRPC.Spec.Rules, 2)
+
+	baseRule := updatedGRPC.Spec.Rules[0]
+	assert.Equal(t, int32(100), *baseRule.BackendRefs[0].Weight, "ruleName must protect the base rule's stable weight")
+	assert.Equal(t, int32(0), *baseRule.BackendRefs[1].Weight, "ruleName must protect the base rule's canary weight")
+
+	argoRule := updatedGRPC.Spec.Rules[1]
+	assert.Equal(t, int32(60), *argoRule.BackendRefs[0].Weight)
+	assert.Equal(t, int32(40), *argoRule.BackendRefs[1].Weight)
+}
+
+// TestSetTCPRouteWeightWithRuleName covers the flat, non-rule-grouped TCPRoute weighting path:
+// ruleName must restrict getBackendRefs to the named rule instead of matching stable/canary
+// BackendRefs anywhere on the route.
+func TestSetTCPRouteWeightWithRuleName(t *testing.T) {
+	tcpRoute := mocks.CreateTCPRouteWithLabels(mocks.TCPRouteName, nil)
+
+	argoRuleName := gatewayv1.SectionName("argo")
+	argoPort := gatewayv1.PortNumber(80)
+	argoStableWeight := int32(100)
+	argoCanaryWeight := int32(0)
+	tcpRoute.Spec.Rules = append(tcpRoute.Spec.Rules, v1alpha2.TCPRouteRule{
+		Name: &argoRuleName,
+		BackendRefs: []v1alpha2.BackendRef{
+			{
+				BackendObjectReference: v1alpha2.BackendObjectReference{
+					Name: mocks.StableServiceName,
+					Port: &argoPort,
+				},
+				Weight: &argoStableWeight,
+			},
+			{
+				BackendObjectReference: v1alpha2.BackendObjectReference{
+					Name: mocks.CanaryServiceName,
+					Port: &argoPort,
+				},
+				Weight: &argoCanaryWeight,
+			},
+		},
+	})
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(tcpRoute),
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+		Namespace:        mocks.RolloutNamespace,
+		TCPRoute:         mocks.TCPRouteName,
+		TCPRouteRuleName: "argo",
+	})
+
+	err := rpcPluginImp.SetWeight(rollout, 25, []v1alpha1.WeightDestination{})
+	assert.Empty(t, err.Error())
+
+	updatedTCP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1alpha2().TCPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.TCPRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+	require.Len(t, updatedTCP.Spec.Rules, 2)
+
+	baseRule := updatedTCP.Spec.Rules[0]
+	assert.Equal(t, int32(100), *baseRule.BackendRefs[0].Weight, "ruleName must protect the base rule's stable weight")
+	assert.Equal(t, int32(0), *baseRule.BackendRefs[1].Weight, "ruleName must protect the base rule's canary weight")
+
+	argoRule := updatedTCP.Spec.Rules[1]
+	assert.Equal(t, int32(75), *argoRule.BackendRefs[0].Weight)
+	assert.Equal(t, int32(25), *argoRule.BackendRefs[1].Weight)
+}
+
+// TestSetTLSRouteWeightWithRuleName mirrors TestSetTCPRouteWeightWithRuleName for TLSRoute.
+func TestSetTLSRouteWeightWithRuleName(t *testing.T) {
+	tlsRoute := mocks.CreateTLSRouteWithLabels(mocks.TLSRouteName, nil)
+
+	argoRuleName := gatewayv1.SectionName("argo")
+	argoPort := gatewayv1.PortNumber(80)
+	argoStableWeight := int32(100)
+	argoCanaryWeight := int32(0)
+	tlsRoute.Spec.Rules = append(tlsRoute.Spec.Rules, v1alpha2.TLSRouteRule{
+		Name: &argoRuleName,
+		BackendRefs: []v1alpha2.BackendRef{
+			{
+				BackendObjectReference: v1alpha2.BackendObjectReference{
+					Name: mocks.StableServiceName,
+					Port: &argoPort,
+				},
+				Weight: &argoStableWeight,
+			},
+			{
+				BackendObjectReference: v1alpha2.BackendObjectReference{
+					Name: mocks.CanaryServiceName,
+					Port: &argoPort,
+				},
+				Weight: &argoCanaryWeight,
+			},
+		},
+	})
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(tlsRoute),
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+		Namespace:        mocks.RolloutNamespace,
+		TLSRoute:         mocks.TLSRouteName,
+		TLSRouteRuleName: "argo",
+	})
+
+	err := rpcPluginImp.SetWeight(rollout, 10, []v1alpha1.WeightDestination{})
+	assert.Empty(t, err.Error())
+
+	updatedTLS, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1alpha2().TLSRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.TLSRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+	require.Len(t, updatedTLS.Spec.Rules, 2)
+
+	baseRule := updatedTLS.Spec.Rules[0]
+	assert.Equal(t, int32(100), *baseRule.BackendRefs[0].Weight, "ruleName must protect the base rule's stable weight")
+	assert.Equal(t, int32(0), *baseRule.BackendRefs[1].Weight, "ruleName must protect the base rule's canary weight")
+
+	argoRule := updatedTLS.Spec.Rules[1]
+	assert.Equal(t, int32(90), *argoRule.BackendRefs[0].Weight)
+	assert.Equal(t, int32(10), *argoRule.BackendRefs[1].Weight)
 }

--- a/pkg/plugin/tcproute.go
+++ b/pkg/plugin/tcproute.go
@@ -26,6 +26,18 @@ func (r *RpcPlugin) setTCPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight i
 		}
 
 		routeRuleList := TCPRouteRuleList(tcpRoute.Spec.Rules)
+		if gatewayAPIConfig.TCPRouteRuleName != "" {
+			filtered := make(TCPRouteRuleList, 0, len(routeRuleList))
+			for _, rule := range routeRuleList {
+				if rule.Name != nil && string(*rule.Name) == gatewayAPIConfig.TCPRouteRuleName {
+					filtered = append(filtered, rule)
+				}
+			}
+			if len(filtered) == 0 {
+				return errors.New(RuleNameNotFoundInTCPRouteError)
+			}
+			routeRuleList = filtered
+		}
 		canaryBackendRefs, err := getBackendRefs(canaryServiceName, routeRuleList)
 		if err != nil {
 			return err
@@ -93,4 +105,11 @@ func (r *TCPBackendRef) GetName() string {
 
 func (r TCPRoute) GetName() string {
 	return r.Name
+}
+
+func (r *TCPRouteRule) GetRuleName() string {
+	if r.Name == nil {
+		return ""
+	}
+	return string(*r.Name)
 }

--- a/pkg/plugin/tlsroute.go
+++ b/pkg/plugin/tlsroute.go
@@ -26,6 +26,18 @@ func (r *RpcPlugin) setTLSRouteWeight(rollout *v1alpha1.Rollout, desiredWeight i
 		}
 
 		routeRuleList := TLSRouteRuleList(tlsRoute.Spec.Rules)
+		if gatewayAPIConfig.TLSRouteRuleName != "" {
+			filtered := make(TLSRouteRuleList, 0, len(routeRuleList))
+			for _, rule := range routeRuleList {
+				if rule.Name != nil && string(*rule.Name) == gatewayAPIConfig.TLSRouteRuleName {
+					filtered = append(filtered, rule)
+				}
+			}
+			if len(filtered) == 0 {
+				return errors.New(RuleNameNotFoundInTLSRouteError)
+			}
+			routeRuleList = filtered
+		}
 		canaryBackendRefs, err := getBackendRefs(canaryServiceName, routeRuleList)
 		if err != nil {
 			return err
@@ -93,4 +105,11 @@ func (r *TLSBackendRef) GetName() string {
 
 func (r TLSRoute) GetName() string {
 	return r.Name
+}
+
+func (r *TLSRouteRule) GetRuleName() string {
+	if r.Name == nil {
+		return ""
+	}
+	return string(*r.Name)
 }

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -25,15 +25,31 @@ type GatewayAPITrafficRouting struct {
 	// HTTPRoute refers to the name of the HTTPRoute used to route traffic to the
 	// service
 	HTTPRoute string `json:"httpRoute,omitempty"`
+	// HTTPRouteRuleName restricts weight/header management for the singular HTTPRoute
+	// above to the rule with this Name, instead of every rule containing both the
+	// canary and stable BackendRefs
+	HTTPRouteRuleName string `json:"httpRouteRuleName,omitempty"`
 	// GRPCRoute refers to the name of the GRPCRoute used to route traffic to the
 	// service
 	GRPCRoute string `json:"grpcRoute,omitempty"`
+	// GRPCRouteRuleName restricts weight/header management for the singular GRPCRoute
+	// above to the rule with this Name, instead of every rule containing both the
+	// canary and stable BackendRefs
+	GRPCRouteRuleName string `json:"grpcRouteRuleName,omitempty"`
 	// TCPRoute refers to the name of the TCPRoute used to route traffic to the
 	// service
 	TCPRoute string `json:"tcpRoute,omitempty"`
+	// TCPRouteRuleName restricts weight management for the singular TCPRoute above to
+	// the rule with this Name, instead of searching every rule for the canary/stable
+	// BackendRefs
+	TCPRouteRuleName string `json:"tcpRouteRuleName,omitempty"`
 	// TLSRoute refers to the name of the TLSRoute used to route traffic to the
 	// service
 	TLSRoute string `json:"tlsRoute,omitempty"`
+	// TLSRouteRuleName restricts weight management for the singular TLSRoute above to
+	// the rule with this Name, instead of searching every rule for the canary/stable
+	// BackendRefs
+	TLSRouteRuleName string `json:"tlsRouteRuleName,omitempty"`
 	// Namespace refers to the namespace of the specified resource
 	Namespace string `json:"namespace,omitempty"`
 	// HTTPRoutes refer to names of HTTPRoute resources used to route traffic to the
@@ -70,6 +86,9 @@ type HTTPRoute struct {
 	// UseHeaderRoutes defines header routes will be added to this route or not
 	// during setHeaderRoute step
 	UseHeaderRoutes bool `json:"useHeaderRoutes,omitempty"`
+	// RuleName restricts weight/header management to the rule with this Name,
+	// instead of every rule containing both the canary and stable BackendRefs
+	RuleName string `json:"ruleName,omitempty"`
 }
 
 type TCPRoute struct {
@@ -78,6 +97,9 @@ type TCPRoute struct {
 	// UseHeaderRoutes indicates header routes will be added to this route or not
 	// during setHeaderRoute step
 	UseHeaderRoutes bool `json:"useHeaderRoutes"`
+	// RuleName restricts weight management to the rule with this Name, instead of
+	// searching every rule for the canary/stable BackendRefs
+	RuleName string `json:"ruleName,omitempty"`
 }
 
 type GRPCRoute struct {
@@ -86,6 +108,9 @@ type GRPCRoute struct {
 	// UseHeaderRoutes indicates header routes will be added to this route or not
 	// during setHeaderRoute step
 	UseHeaderRoutes bool `json:"useHeaderRoutes"`
+	// RuleName restricts weight/header management to the rule with this Name,
+	// instead of every rule containing both the canary and stable BackendRefs
+	RuleName string `json:"ruleName,omitempty"`
 }
 
 type TLSRoute struct {
@@ -94,6 +119,9 @@ type TLSRoute struct {
 	// UseHeaderRoutes indicates header routes will be added to this route or not
 	// during setHeaderRoute step
 	UseHeaderRoutes bool `json:"useHeaderRoutes"`
+	// RuleName restricts weight management to the rule with this Name, instead of
+	// searching every rule for the canary/stable BackendRefs
+	RuleName string `json:"ruleName,omitempty"`
 }
 
 type HTTPRouteRule gatewayv1.HTTPRouteRule
@@ -128,6 +156,7 @@ type GatewayAPIRoute interface {
 type GatewayAPIRouteRule[T1 GatewayAPIBackendRef] interface {
 	*HTTPRouteRule | *GRPCRouteRule | *TCPRouteRule | *TLSRouteRule
 	Iterator() (GatewayAPIRouteRuleIterator[T1], bool)
+	GetRuleName() string
 }
 
 type GatewayAPIRouteRuleList[T1 GatewayAPIBackendRef, T2 GatewayAPIRouteRule[T1]] interface {


### PR DESCRIPTION
## Summary

The plugin currently identifies the rule(s) it manages purely by the presence of the
configured canary/stable BackendRefs (`getAllRouteRules` for HTTPRoute/GRPCRoute,
`getBackendRefs` for TCPRoute/TLSRoute). This means a route with two rules that both
reference `stable`/`canary` — e.g. a live rule carrying the canary/stable split plus an
unrelated static backend, alongside a second rule reserved purely for the plugin to manage
weights on — gets **both** rules rewritten on every reconcile, clobbering the live rule.

This PR adds an optional `ruleName` field that pins weight and header-route management to a
single rule, identified by its Gateway API rule `name` (`HTTPRouteRule.Name`, Extended
support / GEP-995), leaving any other rule with overlapping backend names untouched.

- `httpRoutes[].ruleName`, `grpcRoutes[].ruleName`, `tcpRoutes[].ruleName`,
  `tlsRoutes[].ruleName` for the list config form
- `httpRouteRuleName`, `grpcRouteRuleName`, `tcpRouteRuleName`, `tlsRouteRuleName` mirrored
  singular fields, matching the existing `httpRoute`/`httpRoutes` pattern
- A clear error (`RuleNameNotFoundIn*RouteError`) if the configured `ruleName` doesn't match
  any managed rule, instead of silently matching nothing
- Fully backward compatible: an unset `ruleName` preserves existing behavior exactly

See `docs/features/rule-scoped-weighting.md` for the full write-up and a worked example.

## Test plan

- [x] `make unit-tests` passes, including 6 new tests covering HTTP/GRPC/TCP/TLS weight
      scoping, the not-found error, and header-route scoping
- [x] All existing tests unaffected
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [ ] CI lint (`golangci-lint`) — not run locally, deferred to CI