### PR TITLE
feat: add -kubeconfig and -pluginAlias flags for multi-cluster support

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -193,7 +193,7 @@ Notice that this setting applies **only** to the plugin process. The main Argo R
 
 ### Custom kubeconfig
 
-By default, the plugin uses the standard Kubernetes client configuration discovery. To specify a custom kubeconfig file path, use the `--kubeconfig` flag:
+By default, the plugin uses the standard Kubernetes client configuration discovery. To specify a custom kubeconfig file path, use the `-kubeconfig` flag:
 
 ```yaml
   trafficRouterPlugins: |-

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -190,3 +190,17 @@ using the `args` block of the plugin configuration:
 ```
 
 Notice that this setting applies **only** to the plugin process. The main Argo Rollouts controller is not affected (or any other additional plugins you might have already).
+
+### Custom kubeconfig
+
+By default, the plugin uses the standard Kubernetes client configuration discovery (in-cluster config or `~/.kube/config`). To specify a custom kubeconfig file path, use the `--kubeconfig` flag:
+
+```yaml
+  trafficRouterPlugins: |-
+    - name: "argoproj-labs/gatewayAPI"
+      location: "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/vX.X.X/gatewayapi-plugin-linux-amd64"
+      args:
+      - "-kubeconfig=/path/to/kubeconfig"
+```
+
+This is useful when you need to target a different cluster than the one where Argo Rollouts is running.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -193,7 +193,7 @@ Notice that this setting applies **only** to the plugin process. The main Argo R
 
 ### Custom kubeconfig
 
-By default, the plugin uses the standard Kubernetes client configuration discovery (in-cluster config or `~/.kube/config`). To specify a custom kubeconfig file path, use the `--kubeconfig` flag:
+By default, the plugin uses the standard Kubernetes client configuration discovery. To specify a custom kubeconfig file path, use the `--kubeconfig` flag:
 
 ```yaml
   trafficRouterPlugins: |-

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -204,3 +204,27 @@ By default, the plugin uses the standard Kubernetes client configuration discove
 ```
 
 This is useful when you need to target a different cluster than the one where Argo Rollouts is running.
+
+### Custom plugin alias
+
+By default, the plugin expects its configuration in the Rollout to be under `argoproj-labs/gatewayAPI`. If you need to use a different name (alias) in your Rollout configuration, use the `-pluginAlias` flag:
+
+```yaml
+  trafficRouterPlugins: |-
+    - name: "my-org/gatewayAPI"
+      location: "https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/vX.X.X/gatewayapi-plugin-linux-amd64"
+      args:
+      - "-pluginAlias=my-org/gatewayAPI"
+```
+
+Then in your Rollout, use the same name:
+
+```yaml
+spec:
+  strategy:
+    canary:
+      trafficRouting:
+        plugins:
+          my-org/gatewayAPI:
+            httpRoute: my-route
+```

--- a/internal/utils/common.go
+++ b/internal/utils/common.go
@@ -9,9 +9,12 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func GetKubeConfig() (*rest.Config, error) {
+func GetKubeConfig(kubeConfigPath string) (*rest.Config, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	// if you want to change the loading rules (which files in which order), you can do so here
+	if kubeConfigPath != "" {
+		loadingRules.ExplicitPath = kubeConfigPath
+	}
 	configOverrides := &clientcmd.ConfigOverrides{}
 	// if you want to change override values or bind them to flags, there are methods to help you
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)

--- a/internal/utils/common_test.go
+++ b/internal/utils/common_test.go
@@ -1,10 +1,13 @@
 package utils
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSetupLog_DefaultIsTextFormatter(t *testing.T) {
@@ -33,4 +36,99 @@ func TestSetupLog_JSONFormatterCaseInsensitive(t *testing.T) {
 
 	assert.NotNil(t, entry)
 	assert.IsType(t, &log.JSONFormatter{}, entry.Logger.Formatter)
+}
+
+func TestGetKubeConfig_WithExplicitPath(t *testing.T) {
+	// Create a temporary kubeconfig file
+	tmpDir := t.TempDir()
+	kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
+	kubeconfigContent := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://test-server:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+	err := os.WriteFile(kubeconfigPath, []byte(kubeconfigContent), 0600)
+	require.NoError(t, err)
+
+	config, err := GetKubeConfig(kubeconfigPath)
+
+	require.NoError(t, err)
+	assert.NotNil(t, config)
+	assert.Equal(t, "https://test-server:6443", config.Host)
+}
+
+func TestGetKubeConfig_WithEmptyPath(t *testing.T) {
+	// When empty path is provided, it should use default discovery
+	// This test verifies the function doesn't panic with empty path
+	// The actual result depends on the environment (may succeed or fail)
+	_, _ = GetKubeConfig("")
+}
+
+func TestGetKubeConfig_WithInvalidPath(t *testing.T) {
+	config, err := GetKubeConfig("/nonexistent/path/to/kubeconfig")
+
+	assert.Error(t, err)
+	assert.Nil(t, config)
+}
+
+func TestGetKubeConfig_WithMalformedKubeconfig(t *testing.T) {
+	// Create a temporary kubeconfig file with invalid YAML
+	tmpDir := t.TempDir()
+	kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
+	malformedContent := `this is not valid yaml: [[[`
+	err := os.WriteFile(kubeconfigPath, []byte(malformedContent), 0600)
+	require.NoError(t, err)
+
+	config, err := GetKubeConfig(kubeconfigPath)
+
+	assert.Error(t, err)
+	assert.Nil(t, config)
+}
+
+func TestGetKubeConfig_WithEmptyKubeconfig(t *testing.T) {
+	// Create an empty kubeconfig file
+	tmpDir := t.TempDir()
+	kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
+	err := os.WriteFile(kubeconfigPath, []byte(""), 0600)
+	require.NoError(t, err)
+
+	config, err := GetKubeConfig(kubeconfigPath)
+
+	// Empty kubeconfig should result in an error (no context set)
+	assert.Error(t, err)
+	assert.Nil(t, config)
+}
+
+func TestGetKubeConfig_WithMissingContext(t *testing.T) {
+	// Create a kubeconfig file with missing current-context
+	tmpDir := t.TempDir()
+	kubeconfigPath := filepath.Join(tmpDir, "kubeconfig")
+	kubeconfigContent := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://test-server:6443
+  name: test-cluster
+contexts: []
+users: []
+`
+	err := os.WriteFile(kubeconfigPath, []byte(kubeconfigContent), 0600)
+	require.NoError(t, err)
+
+	config, err := GetKubeConfig(kubeconfigPath)
+
+	assert.Error(t, err)
+	assert.Nil(t, config)
 }

--- a/internal/utils/common_test.go
+++ b/internal/utils/common_test.go
@@ -79,7 +79,7 @@ func TestGetKubeConfig_WithEmptyPath(t *testing.T) {
 func TestGetKubeConfig_WithInvalidPath(t *testing.T) {
 	config, err := GetKubeConfig("/nonexistent/path/to/kubeconfig")
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, config)
 }
 
@@ -93,7 +93,7 @@ func TestGetKubeConfig_WithMalformedKubeconfig(t *testing.T) {
 
 	config, err := GetKubeConfig(kubeconfigPath)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, config)
 }
 
@@ -107,7 +107,7 @@ func TestGetKubeConfig_WithEmptyKubeconfig(t *testing.T) {
 	config, err := GetKubeConfig(kubeconfigPath)
 
 	// Empty kubeconfig should result in an error (no context set)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, config)
 }
 
@@ -129,6 +129,6 @@ users: []
 
 	config, err := GetKubeConfig(kubeconfigPath)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, config)
 }

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 	kubeClientQPS := flag.Int("kubeClientQPS", 5, "The QPS to use for the Kubernetes client.")
 	kubeClientBurst := flag.Int("kubeClientBurst", 10, "The Burst to use for the Kubernetes client.")
 	logFormat := flag.String("logformat", "text", "Set the logging format. One of: text|json")
+	kubeconfig := flag.String("kubeconfig", "", "Path to kubeconfig file. If not set, uses default discovery.")
 	flag.Parse()
 
 	// Create the plugin implementation, injecting command line options:
@@ -32,6 +33,7 @@ func main() {
 		CommandLineOpts: plugin.CommandLineOpts{
 			KubeClientQPS:   float32(*kubeClientQPS),
 			KubeClientBurst: *kubeClientBurst,
+			KubeConfigPath:  *kubeconfig,
 		},
 		LogCtx: utils.SetupLog(*logFormat),
 	}

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 	kubeClientBurst := flag.Int("kubeClientBurst", 10, "The Burst to use for the Kubernetes client.")
 	logFormat := flag.String("logformat", "text", "Set the logging format. One of: text|json")
 	kubeconfig := flag.String("kubeconfig", "", "Path to kubeconfig file. If not set, uses default discovery.")
+	pluginAlias := flag.String("pluginAlias", "", "Alias for the plugin name used in the Rollout configuration. Defaults to argoproj-labs/gatewayAPI.")
 	flag.Parse()
 
 	// Create the plugin implementation, injecting command line options:
@@ -34,6 +35,7 @@ func main() {
 			KubeClientQPS:   float32(*kubeClientQPS),
 			KubeClientBurst: *kubeClientBurst,
 			KubeConfigPath:  *kubeconfig,
+			PluginAlias:     *pluginAlias,
 		},
 		LogCtx: utils.SetupLog(*logFormat),
 	}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -25,7 +25,10 @@ const (
 func (r *RpcPlugin) InitPlugin() pluginTypes.RpcError {
 	log := r.LogCtx
 
-	kubeConfig, err := utils.GetKubeConfig()
+	if r.CommandLineOpts.KubeConfigPath != "" {
+		log.Infof("KubeConfigPath set to: %s", r.CommandLineOpts.KubeConfigPath)
+	}
+	kubeConfig, err := utils.GetKubeConfig(r.CommandLineOpts.KubeConfigPath)
 	if err != nil {
 		return pluginTypes.RpcError{
 			ErrorString: err.Error(),

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -80,7 +80,7 @@ func (r *RpcPlugin) SetWeight(rollout *v1alpha1.Rollout, desiredWeight int32, ad
 	}
 	var rpcError pluginTypes.RpcError
 	if gatewayAPIConfig.HTTPRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls HTTPRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.HTTPRoutes)))
+		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls HTTPRoutes: %v", r.getPluginName(), getGatewayAPIRouteNameList(gatewayAPIConfig.HTTPRoutes)))
 		rpcError = forEachGatewayAPIRoute(gatewayAPIConfig.HTTPRoutes, func(route HTTPRoute) pluginTypes.RpcError {
 			gatewayAPIConfig.HTTPRoute = route.Name
 			return r.setHTTPRouteWeight(rollout, desiredWeight, additionalDestinations, gatewayAPIConfig)
@@ -90,7 +90,7 @@ func (r *RpcPlugin) SetWeight(rollout *v1alpha1.Rollout, desiredWeight int32, ad
 		}
 	}
 	if gatewayAPIConfig.GRPCRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls GRPCRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.GRPCRoutes)))
+		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls GRPCRoutes: %v", r.getPluginName(), getGatewayAPIRouteNameList(gatewayAPIConfig.GRPCRoutes)))
 		rpcError = forEachGatewayAPIRoute(gatewayAPIConfig.GRPCRoutes, func(route GRPCRoute) pluginTypes.RpcError {
 			gatewayAPIConfig.GRPCRoute = route.Name
 			return r.setGRPCRouteWeight(rollout, desiredWeight, gatewayAPIConfig)
@@ -100,7 +100,7 @@ func (r *RpcPlugin) SetWeight(rollout *v1alpha1.Rollout, desiredWeight int32, ad
 		}
 	}
 	if gatewayAPIConfig.TCPRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls TCPRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.TCPRoutes)))
+		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls TCPRoutes: %v", r.getPluginName(), getGatewayAPIRouteNameList(gatewayAPIConfig.TCPRoutes)))
 		rpcError = forEachGatewayAPIRoute(gatewayAPIConfig.TCPRoutes, func(route TCPRoute) pluginTypes.RpcError {
 			gatewayAPIConfig.TCPRoute = route.Name
 			return r.setTCPRouteWeight(rollout, desiredWeight, gatewayAPIConfig)
@@ -110,7 +110,7 @@ func (r *RpcPlugin) SetWeight(rollout *v1alpha1.Rollout, desiredWeight int32, ad
 		}
 	}
 	if gatewayAPIConfig.TLSRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls TLSRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.TLSRoutes)))
+		r.LogCtx.Info(fmt.Sprintf("[SetWeight] plugin %q controls TLSRoutes: %v", r.getPluginName(), getGatewayAPIRouteNameList(gatewayAPIConfig.TLSRoutes)))
 		rpcError = forEachGatewayAPIRoute(gatewayAPIConfig.TLSRoutes, func(route TLSRoute) pluginTypes.RpcError {
 			gatewayAPIConfig.TLSRoute = route.Name
 			return r.setTLSRouteWeight(rollout, desiredWeight, gatewayAPIConfig)
@@ -127,7 +127,7 @@ func (r *RpcPlugin) SetHeaderRoute(rollout *v1alpha1.Rollout, headerRouting *v1a
 		}
 	}
 	if gatewayAPIConfig.HTTPRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[SetHeaderRoute] plugin %q controls HTTPRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.HTTPRoutes)))
+		r.LogCtx.Info(fmt.Sprintf("[SetHeaderRoute] plugin %q controls HTTPRoutes: %v", r.getPluginName(), getGatewayAPIRouteNameList(gatewayAPIConfig.HTTPRoutes)))
 		rpcError := forEachGatewayAPIRoute(gatewayAPIConfig.HTTPRoutes, func(route HTTPRoute) pluginTypes.RpcError {
 			if !route.UseHeaderRoutes {
 				return pluginTypes.RpcError{}
@@ -140,7 +140,7 @@ func (r *RpcPlugin) SetHeaderRoute(rollout *v1alpha1.Rollout, headerRouting *v1a
 		}
 	}
 	if gatewayAPIConfig.GRPCRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[SetHeaderRoute] plugin %q controls GRPCRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.GRPCRoutes)))
+		r.LogCtx.Info(fmt.Sprintf("[SetHeaderRoute] plugin %q controls GRPCRoutes: %v", r.getPluginName(), getGatewayAPIRouteNameList(gatewayAPIConfig.GRPCRoutes)))
 		rpcError := forEachGatewayAPIRoute(gatewayAPIConfig.GRPCRoutes, func(route GRPCRoute) pluginTypes.RpcError {
 			if !route.UseHeaderRoutes {
 				return pluginTypes.RpcError{}
@@ -171,7 +171,7 @@ func (r *RpcPlugin) RemoveManagedRoutes(rollout *v1alpha1.Rollout) pluginTypes.R
 		}
 	}
 	if gatewayAPIConfig.HTTPRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[RemoveManagedRoutes] plugin %q controls HTTPRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.HTTPRoutes)))
+		r.LogCtx.Info(fmt.Sprintf("[RemoveManagedRoutes] plugin %q controls HTTPRoutes: %v", r.getPluginName(), getGatewayAPIRouteNameList(gatewayAPIConfig.HTTPRoutes)))
 		rpcError := forEachGatewayAPIRoute(gatewayAPIConfig.HTTPRoutes, func(route HTTPRoute) pluginTypes.RpcError {
 			if !route.UseHeaderRoutes {
 				return pluginTypes.RpcError{}
@@ -184,7 +184,7 @@ func (r *RpcPlugin) RemoveManagedRoutes(rollout *v1alpha1.Rollout) pluginTypes.R
 		}
 	}
 	if gatewayAPIConfig.GRPCRoutes != nil {
-		r.LogCtx.Info(fmt.Sprintf("[RemoveManagedRoutes] plugin %q controls GRPCRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.GRPCRoutes)))
+		r.LogCtx.Info(fmt.Sprintf("[RemoveManagedRoutes] plugin %q controls GRPCRoutes: %v", r.getPluginName(), getGatewayAPIRouteNameList(gatewayAPIConfig.GRPCRoutes)))
 		rpcError := forEachGatewayAPIRoute(gatewayAPIConfig.GRPCRoutes, func(route GRPCRoute) pluginTypes.RpcError {
 			if !route.UseHeaderRoutes {
 				return pluginTypes.RpcError{}
@@ -204,7 +204,7 @@ func (r *RpcPlugin) Type() string {
 }
 
 func (r *RpcPlugin) getGatewayAPIConfigWithDiscovery(rollout *v1alpha1.Rollout) (*GatewayAPITrafficRouting, error) {
-	gatewayAPIConfig, err := getGatewayAPITrafficRoutingConfig(rollout)
+	gatewayAPIConfig, err := r.getGatewayAPITrafficRoutingConfig(rollout)
 	if err != nil {
 		return nil, err
 	}
@@ -221,10 +221,21 @@ func (r *RpcPlugin) getGatewayAPIConfigWithDiscovery(rollout *v1alpha1.Rollout) 
 	return gatewayAPIConfig, nil
 }
 
-func getGatewayAPITrafficRoutingConfig(rollout *v1alpha1.Rollout) (*GatewayAPITrafficRouting, error) {
+func (r *RpcPlugin) getGatewayAPITrafficRoutingConfig(rollout *v1alpha1.Rollout) (*GatewayAPITrafficRouting, error) {
+	return getGatewayAPITrafficRoutingConfig(rollout, r.getPluginName())
+}
+
+func (r *RpcPlugin) getPluginName() string {
+	if r.CommandLineOpts.PluginAlias != "" {
+		return r.CommandLineOpts.PluginAlias
+	}
+	return PluginName
+}
+
+func getGatewayAPITrafficRoutingConfig(rollout *v1alpha1.Rollout, pluginName string) (*GatewayAPITrafficRouting, error) {
 	validate := validator.New(validator.WithRequiredStructEnabled())
 	gatewayAPIConfig := &GatewayAPITrafficRouting{}
-	err := json.Unmarshal(rollout.Spec.Strategy.Canary.TrafficRouting.Plugins[PluginName], &gatewayAPIConfig)
+	err := json.Unmarshal(rollout.Spec.Strategy.Canary.TrafficRouting.Plugins[pluginName], &gatewayAPIConfig)
 	if err != nil {
 		return gatewayAPIConfig, err
 	}

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -2512,4 +2513,144 @@ func TestSetHTTPHeaderRouteSameHeaderNameDifferentValuesCoexist(t *testing.T) {
 	require.Len(t, route2.Matches, 1)
 	require.Len(t, route2.Matches[0].Headers, 1)
 	assert.Equal(t, "internal", route2.Matches[0].Headers[0].Value)
+}
+
+// TestInitPlugin_WithValidKubeConfigPath tests that InitPlugin successfully initializes
+// when a valid kubeconfig path is provided via CommandLineOpts.
+func TestInitPlugin_WithValidKubeConfigPath(t *testing.T) {
+	// Create a temporary kubeconfig file
+	tmpDir := t.TempDir()
+	kubeconfigPath := tmpDir + "/kubeconfig"
+	kubeconfigContent := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://test-server:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+	err := os.WriteFile(kubeconfigPath, []byte(kubeconfigContent), 0600)
+	require.NoError(t, err)
+
+	rpcPluginImp := &RpcPlugin{
+		CommandLineOpts: CommandLineOpts{
+			KubeConfigPath: kubeconfigPath,
+		},
+		LogCtx: utils.SetupLog("text"),
+	}
+
+	rpcErr := rpcPluginImp.InitPlugin()
+
+	// The plugin initialization will fail because the test server doesn't exist,
+	// but it should at least parse the kubeconfig without error.
+	// We check that it attempted to use the provided kubeconfig by verifying
+	// the clientsets were created (even if they can't connect).
+	assert.NotNil(t, rpcPluginImp.GatewayAPIClientset)
+	assert.NotNil(t, rpcPluginImp.Clientset)
+	assert.Empty(t, rpcErr.ErrorString)
+}
+
+// TestInitPlugin_WithInvalidKubeConfigPath tests that InitPlugin returns an error
+// when an invalid kubeconfig path is provided.
+func TestInitPlugin_WithInvalidKubeConfigPath(t *testing.T) {
+	rpcPluginImp := &RpcPlugin{
+		CommandLineOpts: CommandLineOpts{
+			KubeConfigPath: "/nonexistent/path/to/kubeconfig",
+		},
+		LogCtx: utils.SetupLog("text"),
+	}
+
+	rpcErr := rpcPluginImp.InitPlugin()
+
+	assert.NotEmpty(t, rpcErr.ErrorString)
+	assert.Contains(t, rpcErr.ErrorString, "no such file or directory")
+}
+
+// TestInitPlugin_WithMalformedKubeConfigPath tests that InitPlugin returns an error
+// when a malformed kubeconfig file is provided.
+func TestInitPlugin_WithMalformedKubeConfigPath(t *testing.T) {
+	// Create a temporary kubeconfig file with invalid content
+	tmpDir := t.TempDir()
+	kubeconfigPath := tmpDir + "/kubeconfig"
+	malformedContent := `this is not valid yaml: [[[`
+	err := os.WriteFile(kubeconfigPath, []byte(malformedContent), 0600)
+	require.NoError(t, err)
+
+	rpcPluginImp := &RpcPlugin{
+		CommandLineOpts: CommandLineOpts{
+			KubeConfigPath: kubeconfigPath,
+		},
+		LogCtx: utils.SetupLog("text"),
+	}
+
+	rpcErr := rpcPluginImp.InitPlugin()
+
+	assert.NotEmpty(t, rpcErr.ErrorString)
+}
+
+// TestInitPlugin_WithEmptyKubeConfigPath tests that InitPlugin uses default discovery
+// when no kubeconfig path is provided.
+func TestInitPlugin_WithEmptyKubeConfigPath(t *testing.T) {
+	rpcPluginImp := &RpcPlugin{
+		CommandLineOpts: CommandLineOpts{
+			KubeConfigPath: "",
+		},
+		LogCtx: utils.SetupLog("text"),
+	}
+
+	// This test just verifies the function doesn't panic with an empty path.
+	// The actual result depends on the environment (may succeed or fail based on
+	// whether a default kubeconfig exists).
+	_ = rpcPluginImp.InitPlugin()
+}
+
+// TestInitPlugin_WithKubeClientQPSAndBurst tests that InitPlugin correctly applies
+// QPS and Burst settings from CommandLineOpts when a valid kubeconfig is provided.
+func TestInitPlugin_WithKubeClientQPSAndBurst(t *testing.T) {
+	// Create a temporary kubeconfig file
+	tmpDir := t.TempDir()
+	kubeconfigPath := tmpDir + "/kubeconfig"
+	kubeconfigContent := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://test-server:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+	err := os.WriteFile(kubeconfigPath, []byte(kubeconfigContent), 0600)
+	require.NoError(t, err)
+
+	rpcPluginImp := &RpcPlugin{
+		CommandLineOpts: CommandLineOpts{
+			KubeConfigPath:  kubeconfigPath,
+			KubeClientQPS:   float32(10),
+			KubeClientBurst: 20,
+		},
+		LogCtx: utils.SetupLog("text"),
+	}
+
+	rpcErr := rpcPluginImp.InitPlugin()
+
+	assert.Empty(t, rpcErr.ErrorString)
+	assert.NotNil(t, rpcPluginImp.GatewayAPIClientset)
+	assert.NotNil(t, rpcPluginImp.Clientset)
 }

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -749,7 +749,7 @@ func TestCombinedSelectorAndExplicitRoute(t *testing.T) {
 	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, config)
 
 	// Parse config to verify both are preserved
-	parsedConfig, err := getGatewayAPITrafficRoutingConfig(rollout)
+	parsedConfig, err := getGatewayAPITrafficRoutingConfig(rollout, PluginName)
 	require.NoError(t, err)
 	assert.NotNil(t, parsedConfig.HTTPRouteSelector)
 	assert.Equal(t, "explicit-route", parsedConfig.HTTPRoute)
@@ -770,7 +770,7 @@ func TestNamespaceDefaulting(t *testing.T) {
 		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, config, rolloutNamespace)
 
 		// Parse the config - this is where namespace defaulting should happen
-		parsedConfig, err := getGatewayAPITrafficRoutingConfig(rollout)
+		parsedConfig, err := getGatewayAPITrafficRoutingConfig(rollout, PluginName)
 
 		require.NoError(t, err)
 		// Before the fix, this would be empty string. After the fix, it should default to rollout's namespace.
@@ -788,7 +788,7 @@ func TestNamespaceDefaulting(t *testing.T) {
 		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, config, rolloutNamespace)
 
 		// Parse the config
-		parsedConfig, err := getGatewayAPITrafficRoutingConfig(rollout)
+		parsedConfig, err := getGatewayAPITrafficRoutingConfig(rollout, PluginName)
 
 		require.NoError(t, err)
 		// Should use the explicitly specified namespace, not the rollout's namespace
@@ -804,7 +804,7 @@ func TestNamespaceDefaulting(t *testing.T) {
 		rolloutNamespace := "another-namespace"
 		rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, config, rolloutNamespace)
 
-		parsedConfig, err := getGatewayAPITrafficRoutingConfig(rollout)
+		parsedConfig, err := getGatewayAPITrafficRoutingConfig(rollout, PluginName)
 
 		require.NoError(t, err)
 		assert.Equal(t, rolloutNamespace, parsedConfig.Namespace, "Empty namespace should default to rollout's namespace")
@@ -2653,4 +2653,81 @@ users:
 	assert.Empty(t, rpcErr.ErrorString)
 	assert.NotNil(t, rpcPluginImp.GatewayAPIClientset)
 	assert.NotNil(t, rpcPluginImp.Clientset)
+}
+
+// TestGetPluginName_DefaultPluginName tests that getPluginName returns the default
+// PluginName constant when no alias is configured.
+func TestGetPluginName_DefaultPluginName(t *testing.T) {
+	rpcPlugin := &RpcPlugin{
+		CommandLineOpts: CommandLineOpts{},
+	}
+
+	result := rpcPlugin.getPluginName()
+
+	assert.Equal(t, PluginName, result)
+}
+
+// TestGetPluginName_WithAlias tests that getPluginName returns the configured alias
+// when PluginAlias is set.
+func TestGetPluginName_WithAlias(t *testing.T) {
+	customAlias := "my-org/gatewayAPI"
+	rpcPlugin := &RpcPlugin{
+		CommandLineOpts: CommandLineOpts{
+			PluginAlias: customAlias,
+		},
+	}
+
+	result := rpcPlugin.getPluginName()
+
+	assert.Equal(t, customAlias, result)
+}
+
+// TestSetWeight_WithPluginAlias tests that SetWeight works correctly when using
+// a custom plugin alias.
+func TestSetWeight_WithPluginAlias(t *testing.T) {
+	customAlias := "my-org/gatewayAPI"
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(&mocks.HTTPRouteObj),
+		CommandLineOpts: CommandLineOpts{
+			PluginAlias: customAlias,
+		},
+	}
+
+	// Create rollout with custom alias as the plugin key
+	var desiredWeight int32 = 30
+	config := &GatewayAPITrafficRouting{
+		Namespace: mocks.RolloutNamespace,
+		HTTPRoute: mocks.HTTPRouteName,
+	}
+	encodedConfig, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	rollout := &v1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rollout",
+			Namespace: mocks.RolloutNamespace,
+		},
+		Spec: v1alpha1.RolloutSpec{
+			Strategy: v1alpha1.RolloutStrategy{
+				Canary: &v1alpha1.CanaryStrategy{
+					StableService: mocks.StableServiceName,
+					CanaryService: mocks.CanaryServiceName,
+					TrafficRouting: &v1alpha1.RolloutTrafficRouting{
+						Plugins: map[string]json.RawMessage{
+							customAlias: encodedConfig, // Use custom alias as key
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rpcErr := rpcPluginImp.SetWeight(rollout, desiredWeight, []v1alpha1.WeightDestination{})
+
+	assert.Empty(t, rpcErr.ErrorString)
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+	assert.Equal(t, 100-desiredWeight, *(updatedHTTP.Spec.Rules[0].BackendRefs[0].Weight))
+	assert.Equal(t, desiredWeight, *(updatedHTTP.Spec.Rules[0].BackendRefs[1].Weight))
 }

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -12,6 +12,7 @@ import (
 type CommandLineOpts struct {
 	KubeClientQPS   float32
 	KubeClientBurst int
+	KubeConfigPath  string
 }
 
 type RpcPlugin struct {

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -13,6 +13,7 @@ type CommandLineOpts struct {
 	KubeClientQPS   float32
 	KubeClientBurst int
 	KubeConfigPath  string
+	PluginAlias     string
 }
 
 type RpcPlugin struct {


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Description of this PR

Resolve https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/issues/228. 

Adds two new command-line flags to support multi-cluster deployments:

- `-kubeconfig`: Specify a custom kubeconfig file path to target a different cluster than where Argo Rollouts is running.
- `-pluginAlias`: Specify a custom plugin name for Rollout configuration, enabling multiple plugin instances targeting different clusters.

## Checklist:

* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] My build is green.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged
* [x] The tests actually define testcases about the feature/fix implemented
* [x] I have run all tests locally and they pass
* [x] I haven't changed the existing tests in a significant way, as this will break functionality for existing users <sup>1</sup>
* [x] I've updated documentation as required by this PR.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY it works that way according to my use case
* [x] I understand what the code does and HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My new code is using existing utility functions instead of re-implementing everything again
* [ ] Optional. My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md)

Notes

1. Unless a discussion has happened already in an issue and the breaking change is deemed acceptable
