### PR TITLE
feat: Add support for HTTP route Mirror filters (setMirrorRoute)

### DIFF
--- a/pkg/plugin/httproute.go
+++ b/pkg/plugin/httproute.go
@@ -226,7 +226,7 @@ func (r *RpcPlugin) setHTTPMirrorRoute(rollout *v1alpha1.Rollout, setMirrorRoute
 // setHTTPMirrorRouteAsFilter adds/removes a RequestMirror filter on the existing
 // weighted rules. Both weighted routing and mirroring apply to the same traffic.
 func (r *RpcPlugin) setHTTPMirrorRouteAsFilter(rollout *v1alpha1.Rollout, setMirrorRoute *v1alpha1.SetMirrorRoute, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
-	if setMirrorRoute.Match == nil || len(setMirrorRoute.Match) == 0 {
+	if len(setMirrorRoute.Match) == 0 {
 		return r.removeHTTPMirrorFilter(rollout, gatewayAPIConfig)
 	}
 	ctx := context.TODO()
@@ -303,7 +303,7 @@ func (r *RpcPlugin) removeHTTPMirrorFilter(rollout *v1alpha1.Rollout, gatewayAPI
 // criteria and a RequestMirror filter. Traffic matching the rule goes to stable
 // and is mirrored to canary; other traffic follows the normal weighted rules.
 func (r *RpcPlugin) setHTTPMirrorRouteAsRule(rollout *v1alpha1.Rollout, setMirrorRoute *v1alpha1.SetMirrorRoute, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
-	if setMirrorRoute.Match == nil || len(setMirrorRoute.Match) == 0 {
+	if len(setMirrorRoute.Match) == 0 {
 		return r.removeHTTPMirrorRule(setMirrorRoute.Name, gatewayAPIConfig)
 	}
 	ctx := context.TODO()

--- a/pkg/plugin/httproute.go
+++ b/pkg/plugin/httproute.go
@@ -216,6 +216,327 @@ func getHTTPHeaderRouteRuleList(headerRouting *v1alpha1.SetHeaderRoute) ([]gatew
 	return httpHeaderRouteRuleList, pluginTypes.RpcError{}
 }
 
+func (r *RpcPlugin) setHTTPMirrorRoute(rollout *v1alpha1.Rollout, setMirrorRoute *v1alpha1.SetMirrorRoute, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
+	if gatewayAPIConfig.MirrorMode == "rule" {
+		return r.setHTTPMirrorRouteAsRule(rollout, setMirrorRoute, gatewayAPIConfig)
+	}
+	return r.setHTTPMirrorRouteAsFilter(rollout, setMirrorRoute, gatewayAPIConfig)
+}
+
+// setHTTPMirrorRouteAsFilter adds/removes a RequestMirror filter on the existing
+// weighted rules. Both weighted routing and mirroring apply to the same traffic.
+func (r *RpcPlugin) setHTTPMirrorRouteAsFilter(rollout *v1alpha1.Rollout, setMirrorRoute *v1alpha1.SetMirrorRoute, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
+	if setMirrorRoute.Match == nil || len(setMirrorRoute.Match) == 0 {
+		return r.removeHTTPMirrorFilter(rollout, gatewayAPIConfig)
+	}
+	ctx := context.TODO()
+	httpRouteClient := r.GatewayAPIClientset.GatewayV1().HTTPRoutes(gatewayAPIConfig.Namespace)
+
+	canaryServiceName := rollout.Spec.Strategy.Canary.CanaryService
+	stableServiceName := rollout.Spec.Strategy.Canary.StableService
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		httpRoute, err := httpRouteClient.Get(ctx, gatewayAPIConfig.HTTPRoute, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		weightedRules, err := getAllRouteRules(HTTPRouteRuleList(httpRoute.Spec.Rules), canaryServiceName, stableServiceName)
+		if err != nil {
+			return err
+		}
+
+		mirrorFilter := buildMirrorFilter(rollout, weightedRules, setMirrorRoute.Percentage)
+
+		for _, rule := range weightedRules {
+			stripMirrorFilters(rule)
+			rule.Filters = append(rule.Filters, mirrorFilter)
+		}
+
+		_, err = httpRouteClient.Update(ctx, httpRoute, metav1.UpdateOptions{})
+		return err
+	})
+
+	if err != nil {
+		return pluginTypes.RpcError{
+			ErrorString: err.Error(),
+		}
+	}
+	return pluginTypes.RpcError{}
+}
+
+func (r *RpcPlugin) removeHTTPMirrorFilter(rollout *v1alpha1.Rollout, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
+	ctx := context.TODO()
+	httpRouteClient := r.GatewayAPIClientset.GatewayV1().HTTPRoutes(gatewayAPIConfig.Namespace)
+
+	canaryServiceName := rollout.Spec.Strategy.Canary.CanaryService
+	stableServiceName := rollout.Spec.Strategy.Canary.StableService
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		httpRoute, err := httpRouteClient.Get(ctx, gatewayAPIConfig.HTTPRoute, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		weightedRules, err := getAllRouteRules(HTTPRouteRuleList(httpRoute.Spec.Rules), canaryServiceName, stableServiceName)
+		if err != nil {
+			return nil
+		}
+
+		for _, rule := range weightedRules {
+			stripMirrorFilters(rule)
+		}
+
+		_, err = httpRouteClient.Update(ctx, httpRoute, metav1.UpdateOptions{})
+		return err
+	})
+
+	if err != nil {
+		return pluginTypes.RpcError{
+			ErrorString: err.Error(),
+		}
+	}
+	return pluginTypes.RpcError{}
+}
+
+// setHTTPMirrorRouteAsRule creates a separate managed rule with its own match
+// criteria and a RequestMirror filter. Traffic matching the rule goes to stable
+// and is mirrored to canary; other traffic follows the normal weighted rules.
+func (r *RpcPlugin) setHTTPMirrorRouteAsRule(rollout *v1alpha1.Rollout, setMirrorRoute *v1alpha1.SetMirrorRoute, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
+	if setMirrorRoute.Match == nil || len(setMirrorRoute.Match) == 0 {
+		return r.removeHTTPMirrorRule(setMirrorRoute.Name, gatewayAPIConfig)
+	}
+	ctx := context.TODO()
+	httpRouteClient := r.GatewayAPIClientset.GatewayV1().HTTPRoutes(gatewayAPIConfig.Namespace)
+
+	canaryServiceName := rollout.Spec.Strategy.Canary.CanaryService
+	stableServiceName := rollout.Spec.Strategy.Canary.StableService
+	managedName := gatewayv1.SectionName(setMirrorRoute.Name)
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		httpRoute, err := httpRouteClient.Get(ctx, gatewayAPIConfig.HTTPRoute, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		httpRouteRuleList := HTTPRouteRuleList(httpRoute.Spec.Rules)
+		weightedRules, err := getAllRouteRules(httpRouteRuleList, canaryServiceName, stableServiceName)
+		if err != nil {
+			return err
+		}
+
+		mirrorFilter := buildMirrorFilter(rollout, weightedRules, setMirrorRoute.Percentage)
+		httpMatches := convertRouteMatchesToHTTPRouteMatches(setMirrorRoute.Match)
+
+		stableRefs, err := getBackendRefs(stableServiceName, httpRouteRuleList)
+		if err != nil {
+			return fmt.Errorf("stable service %q not found in HTTPRoute: %w", stableServiceName, err)
+		}
+
+		serviceKind := gatewayv1.Kind("Service")
+		serviceGroup := gatewayv1.Group("")
+
+		mirrorRule := gatewayv1.HTTPRouteRule{
+			Name:    &managedName,
+			Matches: httpMatches,
+			Filters: []gatewayv1.HTTPRouteFilter{mirrorFilter},
+			BackendRefs: []gatewayv1.HTTPBackendRef{
+				{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Group: &serviceGroup,
+							Kind:  &serviceKind,
+							Name:  gatewayv1.ObjectName(stableServiceName),
+							Port:  stableRefs[0].Port,
+						},
+					},
+				},
+			},
+		}
+
+		cleanedRules := make([]gatewayv1.HTTPRouteRule, 0, len(httpRoute.Spec.Rules))
+		for _, rule := range httpRoute.Spec.Rules {
+			if rule.Name != nil && isManagedRuleName(string(*rule.Name), map[string]bool{string(managedName): true}) {
+				continue
+			}
+			cleanedRules = append(cleanedRules, rule)
+		}
+		httpRoute.Spec.Rules = append(cleanedRules, mirrorRule)
+
+		_, err = httpRouteClient.Update(ctx, httpRoute, metav1.UpdateOptions{})
+		return err
+	})
+
+	if err != nil {
+		return pluginTypes.RpcError{
+			ErrorString: err.Error(),
+		}
+	}
+	return pluginTypes.RpcError{}
+}
+
+func (r *RpcPlugin) removeHTTPMirrorRule(mirrorRouteName string, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
+	ctx := context.TODO()
+	httpRouteClient := r.GatewayAPIClientset.GatewayV1().HTTPRoutes(gatewayAPIConfig.Namespace)
+	managedNames := map[string]bool{mirrorRouteName: true}
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		httpRoute, err := httpRouteClient.Get(ctx, gatewayAPIConfig.HTTPRoute, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		newRules := make([]gatewayv1.HTTPRouteRule, 0, len(httpRoute.Spec.Rules))
+		changed := false
+		for _, rule := range httpRoute.Spec.Rules {
+			if rule.Name != nil && isManagedRuleName(string(*rule.Name), managedNames) {
+				changed = true
+				continue
+			}
+			newRules = append(newRules, rule)
+		}
+		if !changed {
+			return nil
+		}
+		httpRoute.Spec.Rules = newRules
+
+		_, err = httpRouteClient.Update(ctx, httpRoute, metav1.UpdateOptions{})
+		return err
+	})
+
+	if err != nil {
+		return pluginTypes.RpcError{
+			ErrorString: err.Error(),
+		}
+	}
+	return pluginTypes.RpcError{}
+}
+
+func buildMirrorFilter(rollout *v1alpha1.Rollout, weightedRules []*HTTPRouteRule, percentage *int32) gatewayv1.HTTPRouteFilter {
+	canaryServiceName := rollout.Spec.Strategy.Canary.CanaryService
+
+	var canaryPort *gatewayv1.PortNumber
+	for _, rule := range weightedRules {
+		for j := range rule.BackendRefs {
+			if string(rule.BackendRefs[j].Name) == canaryServiceName {
+				canaryPort = rule.BackendRefs[j].Port
+				break
+			}
+		}
+		if canaryPort != nil {
+			break
+		}
+	}
+
+	serviceKind := gatewayv1.Kind("Service")
+	serviceGroup := gatewayv1.Group("")
+
+	filter := gatewayv1.HTTPRouteFilter{
+		Type: gatewayv1.HTTPRouteFilterRequestMirror,
+		RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+			BackendRef: gatewayv1.BackendObjectReference{
+				Group: &serviceGroup,
+				Kind:  &serviceKind,
+				Name:  gatewayv1.ObjectName(canaryServiceName),
+				Port:  canaryPort,
+			},
+		},
+	}
+
+	if percentage != nil {
+		filter.RequestMirror.Percent = percentage
+	}
+
+	return filter
+}
+
+func stripMirrorFilters(rule *HTTPRouteRule) {
+	cleaned := make([]gatewayv1.HTTPRouteFilter, 0, len(rule.Filters))
+	for _, f := range rule.Filters {
+		if f.Type != gatewayv1.HTTPRouteFilterRequestMirror {
+			cleaned = append(cleaned, f)
+		}
+	}
+	rule.Filters = cleaned
+}
+
+func convertRouteMatchesToHTTPRouteMatches(matches []v1alpha1.RouteMatch) []gatewayv1.HTTPRouteMatch {
+	httpMatches := make([]gatewayv1.HTTPRouteMatch, 0, len(matches))
+	for _, match := range matches {
+		httpMatch := gatewayv1.HTTPRouteMatch{}
+
+		if match.Method != nil {
+			method := gatewayv1.HTTPMethod(stringMatchValue(match.Method))
+			httpMatch.Method = &method
+		}
+
+		if match.Path != nil {
+			httpMatch.Path = convertStringMatchToPathMatch(match.Path)
+		}
+
+		if match.Headers != nil {
+			for name, headerMatch := range match.Headers {
+				httpMatch.Headers = append(httpMatch.Headers, convertStringMatchToHeaderMatch(name, &headerMatch))
+			}
+		}
+
+		httpMatches = append(httpMatches, httpMatch)
+	}
+	return httpMatches
+}
+
+func stringMatchValue(sm *v1alpha1.StringMatch) string {
+	switch {
+	case sm.Exact != "":
+		return sm.Exact
+	case sm.Prefix != "":
+		return sm.Prefix
+	case sm.Regex != "":
+		return sm.Regex
+	}
+	return ""
+}
+
+func convertStringMatchToPathMatch(sm *v1alpha1.StringMatch) *gatewayv1.HTTPPathMatch {
+	pathMatch := &gatewayv1.HTTPPathMatch{}
+	switch {
+	case sm.Exact != "":
+		pathType := gatewayv1.PathMatchExact
+		pathMatch.Type = &pathType
+		pathMatch.Value = &sm.Exact
+	case sm.Prefix != "":
+		pathType := gatewayv1.PathMatchPathPrefix
+		pathMatch.Type = &pathType
+		pathMatch.Value = &sm.Prefix
+	case sm.Regex != "":
+		pathType := gatewayv1.PathMatchRegularExpression
+		pathMatch.Type = &pathType
+		pathMatch.Value = &sm.Regex
+	}
+	return pathMatch
+}
+
+func convertStringMatchToHeaderMatch(name string, sm *v1alpha1.StringMatch) gatewayv1.HTTPHeaderMatch {
+	headerMatch := gatewayv1.HTTPHeaderMatch{
+		Name: gatewayv1.HTTPHeaderName(name),
+	}
+	switch {
+	case sm.Exact != "":
+		matchType := gatewayv1.HeaderMatchExact
+		headerMatch.Type = &matchType
+		headerMatch.Value = sm.Exact
+	case sm.Regex != "":
+		matchType := gatewayv1.HeaderMatchRegularExpression
+		headerMatch.Type = &matchType
+		headerMatch.Value = sm.Regex
+	case sm.Prefix != "":
+		matchType := gatewayv1.HeaderMatchRegularExpression
+		headerMatch.Type = &matchType
+		headerMatch.Value = sm.Prefix + ".*"
+	}
+	return headerMatch
+}
+
 func (r *RpcPlugin) removeHTTPManagedRoutes(rollout *v1alpha1.Rollout, gatewayAPIConfig *GatewayAPITrafficRouting) pluginTypes.RpcError {
 	ctx := context.TODO()
 	httpRouteClient := r.GatewayAPIClientset.GatewayV1().HTTPRoutes(gatewayAPIConfig.Namespace)

--- a/pkg/plugin/httproute_mirror_test.go
+++ b/pkg/plugin/httproute_mirror_test.go
@@ -1,0 +1,487 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/internal/utils"
+	"github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/pkg/mocks"
+	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwFake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
+)
+
+func TestSetMirrorRouteFilterMode(t *testing.T) {
+	httpRoute := createHTTPRouteWithMatches(mocks.HTTPRouteName, nil, nil, nil, nil)
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
+	}
+
+	percentage := int32(50)
+	mirrorRoute := v1alpha1.SetMirrorRoute{
+		Name:       "mirror-test",
+		Percentage: &percentage,
+		Match: []v1alpha1.RouteMatch{
+			{
+				Method: &v1alpha1.StringMatch{Exact: "GET"},
+			},
+		},
+	}
+
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+		Namespace: mocks.RolloutNamespace,
+		HTTPRoute: mocks.HTTPRouteName,
+	})
+
+	err := rpcPluginImp.setHTTPMirrorRouteAsFilter(rollout, &mirrorRoute, &GatewayAPITrafficRouting{
+		Namespace: mocks.RolloutNamespace,
+		HTTPRoute: mocks.HTTPRouteName,
+	})
+	assert.Empty(t, err.Error())
+
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+
+	rule := updatedHTTP.Spec.Rules[0]
+	hasMirrorFilter := false
+	for _, f := range rule.Filters {
+		if f.Type == gatewayv1.HTTPRouteFilterRequestMirror {
+			hasMirrorFilter = true
+			assert.Equal(t, gatewayv1.ObjectName(mocks.CanaryServiceName), f.RequestMirror.BackendRef.Name)
+			assert.Equal(t, &percentage, f.RequestMirror.Percent)
+		}
+	}
+	assert.True(t, hasMirrorFilter, "Weighted rule should have a RequestMirror filter")
+}
+
+func TestSetMirrorRouteFilterModeRemovesOnEmptyMatch(t *testing.T) {
+	httpRoute := createHTTPRouteWithMatches(mocks.HTTPRouteName, nil, nil, nil, nil)
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
+	}
+
+	config := &GatewayAPITrafficRouting{
+		Namespace: mocks.RolloutNamespace,
+		HTTPRoute: mocks.HTTPRouteName,
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, config)
+
+	percentage := int32(100)
+	addRoute := v1alpha1.SetMirrorRoute{
+		Name:       "mirror-test",
+		Percentage: &percentage,
+		Match: []v1alpha1.RouteMatch{
+			{Method: &v1alpha1.StringMatch{Exact: "POST"}},
+		},
+	}
+	err := rpcPluginImp.setHTTPMirrorRouteAsFilter(rollout, &addRoute, config)
+	assert.Empty(t, err.Error())
+
+	removeRoute := v1alpha1.SetMirrorRoute{
+		Name:  "mirror-test",
+		Match: nil,
+	}
+	err = rpcPluginImp.setHTTPMirrorRouteAsFilter(rollout, &removeRoute, config)
+	assert.Empty(t, err.Error())
+
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+
+	for _, f := range updatedHTTP.Spec.Rules[0].Filters {
+		assert.NotEqual(t, gatewayv1.HTTPRouteFilterRequestMirror, f.Type, "Mirror filter should be removed")
+	}
+}
+
+func TestSetMirrorRouteRuleMode(t *testing.T) {
+	httpRoute := createHTTPRouteWithMatches(mocks.HTTPRouteName, nil, nil, nil, nil)
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
+	}
+
+	config := &GatewayAPITrafficRouting{
+		Namespace:  mocks.RolloutNamespace,
+		HTTPRoute:  mocks.HTTPRouteName,
+		MirrorMode: "rule",
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, config)
+
+	mirrorRoute := v1alpha1.SetMirrorRoute{
+		Name: "mirror-rule",
+		Match: []v1alpha1.RouteMatch{
+			{
+				Headers: map[string]v1alpha1.StringMatch{
+					"X-Test": {Exact: "true"},
+				},
+			},
+		},
+	}
+
+	err := rpcPluginImp.setHTTPMirrorRouteAsRule(rollout, &mirrorRoute, config)
+	assert.Empty(t, err.Error())
+
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+
+	assert.Len(t, updatedHTTP.Spec.Rules, 2, "Should have original rule + managed mirror rule")
+
+	mirrorRuleFound := false
+	for _, rule := range updatedHTTP.Spec.Rules {
+		if rule.Name != nil && string(*rule.Name) == "mirror-rule" {
+			mirrorRuleFound = true
+			hasMirrorFilter := false
+			for _, f := range rule.Filters {
+				if f.Type == gatewayv1.HTTPRouteFilterRequestMirror {
+					hasMirrorFilter = true
+					assert.Equal(t, gatewayv1.ObjectName(mocks.CanaryServiceName), f.RequestMirror.BackendRef.Name)
+				}
+			}
+			assert.True(t, hasMirrorFilter, "Mirror rule should have RequestMirror filter")
+			assert.Equal(t, gatewayv1.ObjectName(mocks.StableServiceName), rule.BackendRefs[0].Name, "Mirror rule should route to stable")
+			assert.NotEmpty(t, rule.Matches, "Mirror rule should have match criteria")
+		}
+	}
+	assert.True(t, mirrorRuleFound, "Should find the managed mirror rule")
+}
+
+func TestSetMirrorRouteRuleModeRemovesOnEmptyMatch(t *testing.T) {
+	httpRoute := createHTTPRouteWithMatches(mocks.HTTPRouteName, nil, nil, nil, nil)
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
+	}
+
+	config := &GatewayAPITrafficRouting{
+		Namespace:  mocks.RolloutNamespace,
+		HTTPRoute:  mocks.HTTPRouteName,
+		MirrorMode: "rule",
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, config)
+
+	addRoute := v1alpha1.SetMirrorRoute{
+		Name: "mirror-rule",
+		Match: []v1alpha1.RouteMatch{
+			{Method: &v1alpha1.StringMatch{Exact: "GET"}},
+		},
+	}
+	err := rpcPluginImp.setHTTPMirrorRouteAsRule(rollout, &addRoute, config)
+	assert.Empty(t, err.Error())
+
+	removeRoute := v1alpha1.SetMirrorRoute{
+		Name:  "mirror-rule",
+		Match: nil,
+	}
+	err = rpcPluginImp.setHTTPMirrorRouteAsRule(rollout, &removeRoute, config)
+	assert.Empty(t, err.Error())
+
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+
+	assert.Len(t, updatedHTTP.Spec.Rules, 1, "Mirror rule should be removed, only original rule remains")
+}
+
+func TestSetMirrorRouteRuleModeReplacesExistingRule(t *testing.T) {
+	httpRoute := createHTTPRouteWithMatches(mocks.HTTPRouteName, nil, nil, nil, nil)
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
+	}
+
+	config := &GatewayAPITrafficRouting{
+		Namespace:  mocks.RolloutNamespace,
+		HTTPRoute:  mocks.HTTPRouteName,
+		MirrorMode: "rule",
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, config)
+
+	firstRoute := v1alpha1.SetMirrorRoute{
+		Name: "mirror-rule",
+		Match: []v1alpha1.RouteMatch{
+			{Method: &v1alpha1.StringMatch{Exact: "GET"}},
+		},
+	}
+	err := rpcPluginImp.setHTTPMirrorRouteAsRule(rollout, &firstRoute, config)
+	assert.Empty(t, err.Error())
+
+	secondRoute := v1alpha1.SetMirrorRoute{
+		Name: "mirror-rule",
+		Match: []v1alpha1.RouteMatch{
+			{Method: &v1alpha1.StringMatch{Exact: "POST"}},
+		},
+	}
+	err = rpcPluginImp.setHTTPMirrorRouteAsRule(rollout, &secondRoute, config)
+	assert.Empty(t, err.Error())
+
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+
+	assert.Len(t, updatedHTTP.Spec.Rules, 2, "Should not duplicate — old rule replaced with new one")
+}
+
+func TestSetMirrorRouteDispatchesToFilterByDefault(t *testing.T) {
+	httpRoute := createHTTPRouteWithMatches(mocks.HTTPRouteName, nil, nil, nil, nil)
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
+	}
+
+	config := &GatewayAPITrafficRouting{
+		Namespace: mocks.RolloutNamespace,
+		HTTPRoute: mocks.HTTPRouteName,
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, config)
+
+	mirrorRoute := v1alpha1.SetMirrorRoute{
+		Name: "mirror-test",
+		Match: []v1alpha1.RouteMatch{
+			{Method: &v1alpha1.StringMatch{Exact: "GET"}},
+		},
+	}
+
+	err := rpcPluginImp.setHTTPMirrorRoute(rollout, &mirrorRoute, config)
+	assert.Empty(t, err.Error())
+
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+
+	assert.Len(t, updatedHTTP.Spec.Rules, 1, "Filter mode should not add new rules")
+	hasMirrorFilter := false
+	for _, f := range updatedHTTP.Spec.Rules[0].Filters {
+		if f.Type == gatewayv1.HTTPRouteFilterRequestMirror {
+			hasMirrorFilter = true
+		}
+	}
+	assert.True(t, hasMirrorFilter, "Default mode should add mirror filter to existing rule")
+}
+
+func TestSetMirrorRouteDispatchesToRuleMode(t *testing.T) {
+	httpRoute := createHTTPRouteWithMatches(mocks.HTTPRouteName, nil, nil, nil, nil)
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
+	}
+
+	config := &GatewayAPITrafficRouting{
+		Namespace:  mocks.RolloutNamespace,
+		HTTPRoute:  mocks.HTTPRouteName,
+		MirrorMode: "rule",
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, config)
+
+	mirrorRoute := v1alpha1.SetMirrorRoute{
+		Name: "mirror-test",
+		Match: []v1alpha1.RouteMatch{
+			{Method: &v1alpha1.StringMatch{Exact: "GET"}},
+		},
+	}
+
+	err := rpcPluginImp.setHTTPMirrorRoute(rollout, &mirrorRoute, config)
+	assert.Empty(t, err.Error())
+
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+
+	assert.Len(t, updatedHTTP.Spec.Rules, 2, "Rule mode should add a new managed rule")
+}
+
+func TestBuildMirrorFilterWithPercentage(t *testing.T) {
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+		Namespace: mocks.RolloutNamespace,
+		HTTPRoute: mocks.HTTPRouteName,
+	})
+
+	port := gatewayv1.PortNumber(80)
+	stableWeight := int32(100)
+	canaryWeight := int32(0)
+	baseRule := gatewayv1.HTTPRouteRule{
+		BackendRefs: []gatewayv1.HTTPBackendRef{
+			{BackendRef: gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{Name: mocks.StableServiceName, Port: &port},
+				Weight:                 &stableWeight,
+			}},
+			{BackendRef: gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{Name: mocks.CanaryServiceName, Port: &port},
+				Weight:                 &canaryWeight,
+			}},
+		},
+	}
+	typedRule := HTTPRouteRule(baseRule)
+	rules := []*HTTPRouteRule{&typedRule}
+
+	percentage := int32(42)
+	filter := buildMirrorFilter(rollout, rules, &percentage)
+
+	assert.Equal(t, gatewayv1.HTTPRouteFilterRequestMirror, filter.Type)
+	assert.Equal(t, gatewayv1.ObjectName(mocks.CanaryServiceName), filter.RequestMirror.BackendRef.Name)
+	assert.Equal(t, &port, filter.RequestMirror.BackendRef.Port)
+	assert.Equal(t, &percentage, filter.RequestMirror.Percent)
+}
+
+func TestBuildMirrorFilterWithoutPercentage(t *testing.T) {
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+		Namespace: mocks.RolloutNamespace,
+		HTTPRoute: mocks.HTTPRouteName,
+	})
+
+	port := gatewayv1.PortNumber(80)
+	stableWeight := int32(100)
+	canaryWeight := int32(0)
+	baseRule := gatewayv1.HTTPRouteRule{
+		BackendRefs: []gatewayv1.HTTPBackendRef{
+			{BackendRef: gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{Name: mocks.StableServiceName, Port: &port},
+				Weight:                 &stableWeight,
+			}},
+			{BackendRef: gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{Name: mocks.CanaryServiceName, Port: &port},
+				Weight:                 &canaryWeight,
+			}},
+		},
+	}
+	typedRule := HTTPRouteRule(baseRule)
+	rules := []*HTTPRouteRule{&typedRule}
+
+	filter := buildMirrorFilter(rollout, rules, nil)
+
+	assert.Equal(t, gatewayv1.HTTPRouteFilterRequestMirror, filter.Type)
+	assert.Nil(t, filter.RequestMirror.Percent, "Percent should be nil when no percentage specified")
+}
+
+func TestStripMirrorFilters(t *testing.T) {
+	baseRule := gatewayv1.HTTPRouteRule{
+		Filters: []gatewayv1.HTTPRouteFilter{
+			{Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier},
+			{Type: gatewayv1.HTTPRouteFilterRequestMirror},
+			{Type: gatewayv1.HTTPRouteFilterURLRewrite},
+			{Type: gatewayv1.HTTPRouteFilterRequestMirror},
+		},
+	}
+	rule := HTTPRouteRule(baseRule)
+
+	stripMirrorFilters(&rule)
+
+	assert.Len(t, rule.Filters, 2, "Should remove all mirror filters")
+	for _, f := range rule.Filters {
+		assert.NotEqual(t, gatewayv1.HTTPRouteFilterRequestMirror, f.Type)
+	}
+}
+
+func TestConvertRouteMatchesToHTTPRouteMatches(t *testing.T) {
+	matches := []v1alpha1.RouteMatch{
+		{
+			Method: &v1alpha1.StringMatch{Exact: "POST"},
+			Path:   &v1alpha1.StringMatch{Prefix: "/api"},
+			Headers: map[string]v1alpha1.StringMatch{
+				"X-Test": {Exact: "true"},
+			},
+		},
+	}
+
+	httpMatches := convertRouteMatchesToHTTPRouteMatches(matches)
+
+	require.Len(t, httpMatches, 1)
+	assert.Equal(t, gatewayv1.HTTPMethod("POST"), *httpMatches[0].Method)
+	assert.Equal(t, gatewayv1.PathMatchPathPrefix, *httpMatches[0].Path.Type)
+	assert.Equal(t, "/api", *httpMatches[0].Path.Value)
+	require.Len(t, httpMatches[0].Headers, 1)
+	assert.Equal(t, gatewayv1.HTTPHeaderName("X-Test"), httpMatches[0].Headers[0].Name)
+}
+
+func TestConvertRouteMatchesEmptyFields(t *testing.T) {
+	matches := []v1alpha1.RouteMatch{
+		{},
+	}
+
+	httpMatches := convertRouteMatchesToHTTPRouteMatches(matches)
+
+	require.Len(t, httpMatches, 1)
+	assert.Nil(t, httpMatches[0].Method)
+	assert.Nil(t, httpMatches[0].Path)
+	assert.Nil(t, httpMatches[0].Headers)
+}
+
+func TestSetMirrorRouteFilterModeNoPercentage(t *testing.T) {
+	httpRoute := createHTTPRouteWithMatches(mocks.HTTPRouteName, nil, nil, nil, nil)
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
+	}
+
+	mirrorRoute := v1alpha1.SetMirrorRoute{
+		Name: "mirror-test",
+		Match: []v1alpha1.RouteMatch{
+			{Method: &v1alpha1.StringMatch{Exact: "GET"}},
+		},
+	}
+
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+		Namespace: mocks.RolloutNamespace,
+		HTTPRoute: mocks.HTTPRouteName,
+	})
+	config := &GatewayAPITrafficRouting{
+		Namespace: mocks.RolloutNamespace,
+		HTTPRoute: mocks.HTTPRouteName,
+	}
+
+	err := rpcPluginImp.setHTTPMirrorRouteAsFilter(rollout, &mirrorRoute, config)
+	assert.Empty(t, err.Error())
+
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+
+	for _, f := range updatedHTTP.Spec.Rules[0].Filters {
+		if f.Type == gatewayv1.HTTPRouteFilterRequestMirror {
+			assert.Nil(t, f.RequestMirror.Percent, "No percentage should mean nil Percent on filter")
+		}
+	}
+}
+
+func TestSetMirrorRouteRuleModeWithPathMatch(t *testing.T) {
+	httpRoute := createHTTPRouteWithMatches(mocks.HTTPRouteName, nil, nil, nil, nil)
+
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gwFake.NewSimpleClientset(httpRoute),
+	}
+
+	config := &GatewayAPITrafficRouting{
+		Namespace:  mocks.RolloutNamespace,
+		HTTPRoute:  mocks.HTTPRouteName,
+		MirrorMode: "rule",
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, config)
+
+	mirrorRoute := v1alpha1.SetMirrorRoute{
+		Name: "mirror-path",
+		Match: []v1alpha1.RouteMatch{
+			{
+				Path: &v1alpha1.StringMatch{Prefix: "/api/v2"},
+			},
+		},
+	}
+
+	err := rpcPluginImp.setHTTPMirrorRouteAsRule(rollout, &mirrorRoute, config)
+	assert.Empty(t, err.Error())
+
+	updatedHTTP, getErr := rpcPluginImp.GatewayAPIClientset.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+
+	require.Len(t, updatedHTTP.Spec.Rules, 2)
+	managedRule := updatedHTTP.Spec.Rules[1]
+	require.NotEmpty(t, managedRule.Matches)
+	assert.Equal(t, "/api/v2", *managedRule.Matches[0].Path.Value)
+	assert.Equal(t, gatewayv1.PathMatchPathPrefix, *managedRule.Matches[0].Path.Type)
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -153,6 +153,25 @@ func (r *RpcPlugin) SetHeaderRoute(rollout *v1alpha1.Rollout, headerRouting *v1a
 }
 
 func (r *RpcPlugin) SetMirrorRoute(rollout *v1alpha1.Rollout, setMirrorRoute *v1alpha1.SetMirrorRoute) pluginTypes.RpcError {
+	gatewayAPIConfig, err := r.getGatewayAPIConfigWithDiscovery(rollout)
+	if err != nil {
+		return pluginTypes.RpcError{
+			ErrorString: err.Error(),
+		}
+	}
+	if gatewayAPIConfig.HTTPRoutes != nil {
+		r.LogCtx.Info(fmt.Sprintf("[SetMirrorRoute] plugin %q controls HTTPRoutes: %v", PluginName, getGatewayAPIRouteNameList(gatewayAPIConfig.HTTPRoutes)))
+		rpcError := forEachGatewayAPIRoute(gatewayAPIConfig.HTTPRoutes, func(route HTTPRoute) pluginTypes.RpcError {
+			if !route.UseHeaderRoutes {
+				return pluginTypes.RpcError{}
+			}
+			gatewayAPIConfig.HTTPRoute = route.Name
+			return r.setHTTPMirrorRoute(rollout, setMirrorRoute, gatewayAPIConfig)
+		})
+		if rpcError.HasError() {
+			return rpcError
+		}
+	}
 	return pluginTypes.RpcError{}
 }
 

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -56,6 +56,10 @@ type GatewayAPITrafficRouting struct {
 	TCPRouteSelector *metav1.LabelSelector `json:"tcpRouteSelector,omitempty"`
 	// TLSRouteSelector refers to label selector for auto-discovery of TLSRoutes
 	TLSRouteSelector *metav1.LabelSelector `json:"tlsRouteSelector,omitempty"`
+	// MirrorMode controls how setMirrorRoute is applied to the HTTPRoute.
+	// "filter" (default) adds a RequestMirror filter to the existing weighted rule.
+	// "rule" creates a separate managed rule with its own matches and the mirror filter.
+	MirrorMode string `json:"mirrorMode,omitempty"`
 	// DisableInProgressLabel disables the automatic label that marks routes as managed during canary steps
 	DisableInProgressLabel bool `json:"disableInProgressLabel,omitempty"`
 	// InProgressLabelKey overrides the label key used while a canary is running


### PR DESCRIPTION
## Description of this PR
- Adds `setMirrorRoute` support for the Gateway API traffic router plugin, enabling mirror/shadow traffic during Argo Rollouts canary steps
- Implements two modes via `mirrorMode` config:
  - `filter` (default) — adds a `RequestMirror` filter to the existing weighted rule
  - `rule` — creates a separate managed HTTPRoute rule with its own matches and mirror filter
- New fields in `GatewayAPITrafficRouting`: `mirrorMode` (string, optional)

## Checklist:
  * [x] I have added a brief description of why this PR is necessary and/or what this PR
  solves.
  * [x] I have signed off all my commits as required by DCO
  * [ ] My build is green.
  * [x] I have written unit and/or e2e tests for my change. PRs without these are
  unlikely to be merged
  * [x] The tests actually define testcases about the feature/fix implemented
  * [x] I have run all tests locally and they pass
  * [x] I haven't changed the existing tests in a significant way
  * [ ] I've updated documentation as required by this PR.
  * [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of
  this PR
  * [x] I understand what the code does and WHY it works that way according to my use case
  * [x] I understand what the code does and HOW it works in several scenarios
  * [x] I know if my code is just adding new functionality or changing old functionality for existing users
  * [x] My new code is using existing utility functions instead of re-implementingeverything

## Changes
- `pkg/plugin/httproute.go` — core mirror route logic (set/remove mirror filters and rules)
- `pkg/plugin/plugin.go` — wires `SetMirrorRoute` and `RemoveManagedRoutes` into the plugin interface
- `pkg/plugin/types.go` — adds `MirrorMode` field to config struct


Made with help from [Cursor](https://cursor.com)