### PR TITLE
fix(http): skip unchanged HTTPRoute updates

### DIFF
--- a/pkg/plugin/httproute.go
+++ b/pkg/plugin/httproute.go
@@ -8,6 +8,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	pluginTypes "github.com/argoproj/argo-rollouts/utils/plugin/types"
 	"github.com/argoproj/argo-rollouts/utils/weightutil"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -26,6 +27,7 @@ func (r *RpcPlugin) setHTTPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight 
 		if err != nil {
 			return err
 		}
+		originalSpec := httpRoute.Spec.DeepCopy()
 
 		// Only rules containing BOTH the canary and stable BackendRefs are weight-split
 		// rules under this plugin's control. A rule referencing just one of them (e.g. a
@@ -51,7 +53,11 @@ func (r *RpcPlugin) setHTTPRouteWeight(rollout *v1alpha1.Rollout, desiredWeight 
 			r.LogCtx.Error(err, "Failed to handle experiment services")
 		}
 
-		ensureInProgressLabel(httpRoute, desiredWeight, gatewayAPIConfig)
+		labelModified := ensureInProgressLabel(httpRoute, desiredWeight, gatewayAPIConfig)
+
+		if apiequality.Semantic.DeepEqual(originalSpec, &httpRoute.Spec) && !labelModified {
+			return nil
+		}
 
 		_, err = httpRouteClient.Update(ctx, httpRoute, metav1.UpdateOptions{})
 		return err

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -2513,3 +2513,68 @@ func TestSetHTTPHeaderRouteSameHeaderNameDifferentValuesCoexist(t *testing.T) {
 	require.Len(t, route2.Matches[0].Headers, 1)
 	assert.Equal(t, "internal", route2.Matches[0].Headers[0].Value)
 }
+
+// TestSetHTTPRouteWeightSkipsUnchangedUpdate reproduces issue #230:
+// https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/issues/230
+func TestSetHTTPRouteWeightSkipsUnchangedUpdate(t *testing.T) {
+	httpRoute := mocks.CreateHTTPRouteWithLabels(mocks.HTTPRouteName, nil)
+	gatewayClient := gwFake.NewSimpleClientset(httpRoute)
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gatewayClient,
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+		Namespace: mocks.RolloutNamespace,
+		HTTPRoute: mocks.HTTPRouteName,
+	})
+
+	err := rpcPluginImp.SetWeight(rollout, 30, []v1alpha1.WeightDestination{})
+	require.Empty(t, err.Error())
+
+	countUpdates := func() int {
+		updates := 0
+		for _, action := range gatewayClient.Actions() {
+			if action.GetVerb() == "update" && action.GetResource().Resource == "httproutes" {
+				updates++
+			}
+		}
+		return updates
+	}
+	require.Equal(t, 1, countUpdates(), "the initial weight and label change must update the HTTPRoute")
+
+	err = rpcPluginImp.SetWeight(rollout, 30, []v1alpha1.WeightDestination{})
+	require.Empty(t, err.Error())
+	require.Equal(t, 1, countUpdates(), "an unchanged desired state must not update the HTTPRoute again")
+}
+
+func TestSetHTTPRouteWeightUpdatesChangedLabelWhenWeightsAreUnchanged(t *testing.T) {
+	httpRoute := mocks.CreateHTTPRouteWithLabels(mocks.HTTPRouteName, nil)
+	stableWeight := int32(70)
+	canaryWeight := int32(30)
+	httpRoute.Spec.Rules[0].BackendRefs[0].Weight = &stableWeight
+	httpRoute.Spec.Rules[0].BackendRefs[1].Weight = &canaryWeight
+	gatewayClient := gwFake.NewSimpleClientset(httpRoute)
+	rpcPluginImp := &RpcPlugin{
+		LogCtx:              utils.SetupLog("text"),
+		GatewayAPIClientset: gatewayClient,
+	}
+	rollout := newRollout(mocks.StableServiceName, mocks.CanaryServiceName, &GatewayAPITrafficRouting{
+		Namespace: mocks.RolloutNamespace,
+		HTTPRoute: mocks.HTTPRouteName,
+	})
+
+	err := rpcPluginImp.SetWeight(rollout, 30, []v1alpha1.WeightDestination{})
+	require.Empty(t, err.Error())
+
+	updates := 0
+	for _, action := range gatewayClient.Actions() {
+		if action.GetVerb() == "update" && action.GetResource().Resource == "httproutes" {
+			updates++
+		}
+	}
+	require.Equal(t, 1, updates, "a changed in-progress label must update the HTTPRoute")
+
+	updatedHTTPRoute, getErr := gatewayClient.GatewayV1().HTTPRoutes(mocks.RolloutNamespace).Get(context.Background(), mocks.HTTPRouteName, metav1.GetOptions{})
+	require.NoError(t, getErr)
+	require.Equal(t, defaults.InProgressLabelValue, updatedHTTPRoute.Labels[defaults.InProgressLabelKey])
+}


### PR DESCRIPTION
## Description of this PR

Fixes #230.

`SetWeight` may be called repeatedly during normal Argo Rollouts reconciliation. The Gateway API plugin currently turns every call into an `HTTPRoute.Update`, even when the route already matches the desired weights and plugin-managed label.

This change:

* snapshots the HTTPRoute spec after each fresh GET inside `RetryOnConflict`;
* reconciles weights, experiment backends, and the in-progress label as before;
* skips the Update only when both the spec and plugin-managed label are unchanged;
* adds regression coverage for repeated identical calls and for a label-only change.

The check remains inside the conflict retry closure, so every retry evaluates the latest object. External drift is still corrected because a changed spec does not pass the no-op check.

This reduces unnecessary API server, admission, audit, watch, and downstream Gateway controller work without changing routing behavior.

## Verification

* `make coverage` with Go 1.24.9 — passed (`pkg/plugin` coverage: 76.7%)
* `golangci-lint run --timeout 6m` with v2.11.4 — 0 issues
* `go build -v ./...` — passed
* `go test -race -count=1 ./pkg/plugin` — passed

## Checklist

* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] I have signed off all my commits as required by DCO.
* [x] My local build and test suite are green.
* [x] I have written unit tests for the fix.
* [x] The tests define the unchanged-state and label-change cases.
* [x] I haven't changed existing tests in a significant way.
* [x] No documentation change is required because behavior and configuration are unchanged.
* [x] I used LLM/AI/Agent tools for this PR and remain responsible for the code.
* [x] I understand why and how the no-op check works across repeated reconciliation, label transitions, experiment changes, and conflict retries.
* [x] This fixes existing behavior without adding a new configuration surface.
* [x] The implementation uses Kubernetes semantic equality and the existing `ensureInProgressLabel` result instead of duplicating comparison logic.
