### PR TITLE
chore: bump argo-rollouts Helm chart to 2.43.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,7 @@ CHAINSAW_VERSION=v0.2.15
 # Versions of components used in e2e tests
 GATEWAY_API_VERSION=v1.4.0
 # See more versions at https://artifacthub.io/packages/helm/argo/argo-rollouts
-# Controller image tag is overridden to v1.10.0 in test/cluster-setup/argo-rollouts-values.yml
-# (no chart with that appVersion exists yet; needed for pingPong support).
-ARGO_ROLLOUTS_HELM_VERSION=2.41.1 # Chart's appVersion is 1.9.1, controller image pinned to v1.10.0
+ARGO_ROLLOUTS_HELM_VERSION=2.43.0 # Contains Argo Rollouts v1.10.0
 # See more versions at https://artifacthub.io/packages/helm/traefik/traefik
 TRAEFIK_HELM_VERSION=37.4.0 # Contains Traefik proxy v3.6.2
 

--- a/test/cluster-setup/argo-rollouts-values.yml
+++ b/test/cluster-setup/argo-rollouts-values.yml
@@ -4,12 +4,6 @@ controller:
 
   replicas: 1
 
-  # Pin the controller image to a release newer than the chart's appVersion.
-  # Needed for pingPong (argoproj/argo-rollouts#4740), first shipped in v1.10.0 —
-  # no Helm chart with that appVersion exists yet.
-  image:
-    tag: v1.10.0
-
   logging:
     level: debug
 


### PR DESCRIPTION
## Description of this PR

Bumps the argo-rollouts Helm chart used in e2e tests to 2.43.0, which now ships `appVersion: v1.10.0`. Removes the `controller.image.tag: v1.10.0` override in `test/cluster-setup/argo-rollouts-values.yml` that was a temporary workaround while no chart shipped that version yet (needed for pingPong support, #201). This is a test-infrastructure-only change; it does not affect plugin behavior for existing users.

## Checklist:

* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] My build is green.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged
* [x] The tests actually define testcases about the feature/fix implemented
* [x] I have run all tests locally and they pass
* [x] I haven't changed the existing tests in a significant way, as this will break functionality for existing users <sup>1</sup>
* [x] I've updated documentation as required by this PR.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY it works that way according to my use case
* [x] I understand what the code does and HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My new code is using existing utility functions instead of re-implementing everything again
* [ ] Optional. My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md)

Notes

1. Unless a discussion has happened already in an issue and the breaking change is deemed acceptable