### PR TITLE
fix: escape and anchor prefix header matches

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,22 +1,12 @@
 # Changes
 
-## Ping pong (alternating stable with preview)
+## Prefix header matches are now escaped and anchored
 
-Added support for the [pingPong](https://rollouts-plugin-trafficrouter-gatewayapi.readthedocs.io/en/latest/features/ping-pong/) traffic routing strategy  on all route types (HTTPRoute, GRPCRoute, TCPRoute, TLSRoute) allowing zero-downtime deployments for long lived connections. This was previously available
-only for [ALB](https://argo-rollouts.readthedocs.io/en/stable/features/traffic-management/alb/#zero-downtime-updates-with-ping-pong-feature) and [istio](https://argo-rollouts.readthedocs.io/en/stable/features/traffic-management/istio/#ping-pong).
+A `setHeaderRoute` step with a `prefix` header match is turned into a Gateway API `RegularExpression` header match, because Gateway API has no prefix match type for headers. The plugin used to build that expression as `<prefix>.*`, with the prefix inserted verbatim. It now builds `^<prefix>.*`, with the prefix escaped.
 
-Ping pong Requires Argo Rollouts v1.10.0 or later.
+Two things change for existing users:
 
-## Fine grained canaries
+- Regular expression characters in the prefix are no longer interpreted. `prefix: v1.0` also matched `v1x0`, and `prefix: a+b` did not match the value `a+b` at all. Both now behave as a plain prefix.
+- The expression is anchored. Gateway API leaves `RegularExpression` semantics to the implementation. Envoy based implementations match the whole header value, so `canary.*` already behaved as a prefix there. Traefik evaluates the expression as an unanchored search, so `canary.*` also matched `not-canary` and sent those requests to the canary.
 
-Added support for `maxTrafficWeight` for values over 100.
-
-Note that this MAY change the behavior of rollouts with `maxTrafficWeight` already set, where all `setWeight` use values not more than 100. For instance, `setWeight: 10` with `maxTrafficWeight: 1000` will now route **1%** of the traffic, **NOT** 10%. If you use such settings, you should review the `setWeight` values.
-
-## Other changes
-
-- Fixed experiment percentage calculation
-- Tested with HaProxy gateway API implementation
-- Started e2e tests for experiments
-- Added code coverage calculation in CI
-
+On Envoy based implementations this matches exactly the same header values as before, as long as the prefix contains no regular expression characters. On Traefik, header values that merely contain the prefix are no longer routed to the canary, which is the prefix behavior documented by Argo Rollouts. If you relied on the previous unanchored matching, use a `regex` header match instead of a `prefix` one.

--- a/pkg/plugin/grpcroute.go
+++ b/pkg/plugin/grpcroute.go
@@ -200,7 +200,7 @@ func getGRPCHeaderRouteRuleList(headerRouting *v1alpha1.SetHeaderRoute) ([]gatew
 		case headerRule.HeaderValue.Prefix != "":
 			headerMatchType := gatewayv1.GRPCHeaderMatchRegularExpression
 			grpcHeaderRouteRule.Type = &headerMatchType
-			grpcHeaderRouteRule.Value = headerRule.HeaderValue.Prefix + ".*"
+			grpcHeaderRouteRule.Value = prefixHeaderMatchRegex(headerRule.HeaderValue.Prefix)
 		case headerRule.HeaderValue.Regex != "":
 			headerMatchType := gatewayv1.GRPCHeaderMatchRegularExpression
 			grpcHeaderRouteRule.Type = &headerMatchType

--- a/pkg/plugin/httproute.go
+++ b/pkg/plugin/httproute.go
@@ -207,7 +207,7 @@ func getHTTPHeaderRouteRuleList(headerRouting *v1alpha1.SetHeaderRoute) ([]gatew
 		case headerRule.HeaderValue.Prefix != "":
 			headerMatchType := gatewayv1.HeaderMatchRegularExpression
 			httpHeaderRouteRule.Type = &headerMatchType
-			httpHeaderRouteRule.Value = headerRule.HeaderValue.Prefix + ".*"
+			httpHeaderRouteRule.Value = prefixHeaderMatchRegex(headerRule.HeaderValue.Prefix)
 		case headerRule.HeaderValue.Regex != "":
 			headerMatchType := gatewayv1.HeaderMatchRegularExpression
 			httpHeaderRouteRule.Type = &headerMatchType

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -372,6 +373,19 @@ func insertGatewayAPIRouteLists(gatewayAPIConfig *GatewayAPITrafficRouting) {
 			UseHeaderRoutes: true,
 		})
 	}
+}
+
+// prefixHeaderMatchRegex converts a header prefix match into a RegularExpression
+// header match value. Gateway API has no prefix match type for headers, so the
+// prefix is expressed as a regular expression. The prefix is escaped so that
+// characters like "." or "+" match literally, and the expression is anchored with
+// "^" because implementations differ in how they apply the regular expression:
+// Envoy based implementations match the whole header value, while for example
+// Traefik uses an unanchored search, where "canary.*" would also match
+// "not-canary". The trailing ".*" keeps the expression valid for implementations
+// that require the whole value to match.
+func prefixHeaderMatchRegex(prefix string) string {
+	return "^" + regexp.QuoteMeta(prefix) + ".*"
 }
 
 // isManagedRuleName reports whether ruleName was produced by this plugin for any of

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"encoding/json"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -319,7 +320,7 @@ func TestRunSuccessfully(t *testing.T) {
 		headerName := "X-Test"
 		headerValue := "test"
 		headerValueType := gatewayv1.HeaderMatchRegularExpression
-		prefixedHeaderValue := headerValue + ".*"
+		prefixedHeaderValue := "^" + headerValue + ".*"
 		headerMatch := v1alpha1.StringMatch{
 			Prefix: headerValue,
 		}
@@ -350,7 +351,7 @@ func TestRunSuccessfully(t *testing.T) {
 		headerName := "X-Test"
 		headerValue := "test"
 		headerValueType := gatewayv1.GRPCHeaderMatchRegularExpression
-		prefixedHeaderValue := headerValue + ".*"
+		prefixedHeaderValue := "^" + headerValue + ".*"
 		headerMatch := v1alpha1.StringMatch{
 			Prefix: headerValue,
 		}
@@ -707,6 +708,78 @@ func TestRunSuccessfully(t *testing.T) {
 	// Canceling should cause an exit
 	cancel()
 	<-closeCh
+}
+
+func TestPrefixHeaderMatchRegex(t *testing.T) {
+	// Gateway API has no prefix header match, so a prefix is expressed as a regular
+	// expression. Implementations differ in how they apply it: Envoy based ones match
+	// the whole header value, Traefik uses an unanchored search. The expression must
+	// therefore be anchored and the prefix escaped so it only matches values that
+	// literally start with the prefix under both interpretations.
+	testCases := []struct {
+		prefix      string
+		expected    string
+		matching    []string
+		nonMatching []string
+	}{
+		{
+			prefix:      "canary",
+			expected:    "^canary.*",
+			matching:    []string{"canary", "canary-v2"},
+			nonMatching: []string{"not-canary", "xcanaryx", ""},
+		},
+		{
+			prefix:      "v1.0",
+			expected:    "^v1\\.0.*",
+			matching:    []string{"v1.0", "v1.0-beta"},
+			nonMatching: []string{"v1x0", "av1.0"},
+		},
+		{
+			prefix:      "a+b",
+			expected:    "^a\\+b.*",
+			matching:    []string{"a+b", "a+bc"},
+			nonMatching: []string{"aab", "ab"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.prefix, func(t *testing.T) {
+			actual := prefixHeaderMatchRegex(tc.prefix)
+			assert.Equal(t, tc.expected, actual)
+
+			search := regexp.MustCompile(actual)                // unanchored search, as Traefik does
+			whole := regexp.MustCompile("^(?:" + actual + ")$") // whole value match, as Envoy does
+			for _, value := range tc.matching {
+				assert.True(t, search.MatchString(value), "search should match %q", value)
+				assert.True(t, whole.MatchString(value), "whole match should match %q", value)
+			}
+			for _, value := range tc.nonMatching {
+				assert.False(t, search.MatchString(value), "search should not match %q", value)
+				assert.False(t, whole.MatchString(value), "whole match should not match %q", value)
+			}
+		})
+	}
+}
+
+func TestHeaderRouteRuleListPrefixIsEscapedAndAnchored(t *testing.T) {
+	headerRouting := &v1alpha1.SetHeaderRoute{
+		Name: mocks.ManagedRouteName,
+		Match: []v1alpha1.HeaderRoutingMatch{
+			{
+				HeaderName:  "X-Version",
+				HeaderValue: &v1alpha1.StringMatch{Prefix: "v1.0"},
+			},
+		},
+	}
+
+	httpMatches, rpcErr := getHTTPHeaderRouteRuleList(headerRouting)
+	assert.Empty(t, rpcErr.Error())
+	assert.Equal(t, gatewayv1.HeaderMatchRegularExpression, *httpMatches[0].Type)
+	assert.Equal(t, "^v1\\.0.*", httpMatches[0].Value)
+
+	grpcMatches, rpcErr := getGRPCHeaderRouteRuleList(headerRouting)
+	assert.Empty(t, rpcErr.Error())
+	assert.Equal(t, gatewayv1.GRPCHeaderMatchRegularExpression, *grpcMatches[0].Type)
+	assert.Equal(t, "^v1\\.0.*", grpcMatches[0].Value)
 }
 
 func TestHTTPRouteWithSelector(t *testing.T) {


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

## Description of this PR

Fixes #237

A `prefix` header match in `setHeaderRoute` is converted into a `RegularExpression` header match. The prefix was used verbatim followed by `.*`, so regular expression characters in the prefix were interpreted (`v1.0` matched `v1x0`, `a+b` did not match `a+b`) and, on implementations that apply the expression as an unanchored search such as Traefik, `canary.*` also matched `not-canary`.

This PR adds `prefixHeaderMatchRegex`, used by both the HTTPRoute and GRPCRoute handlers, which escapes the prefix with `regexp.QuoteMeta` and anchors the expression with `^`. The trailing `.*` is kept so implementations that match the whole header value, such as Envoy based ones, still accept any value starting with the prefix.

Effect on existing users: the injected rule value changes from `<prefix>.*` to `^<prefix>.*` (escaped). For Envoy based implementations this matches exactly the same values as before whenever the prefix has no regular expression characters. For Traefik it stops matching values that merely contain the prefix, which is the documented prefix semantics of Argo Rollouts.

Verified on a kind cluster built with `make setup-e2e-cluster` (Traefik 3.6.2, Argo Rollouts 1.10.0), stable pods `rollouts-demo:blue`, canary pods `rollouts-demo:green`, a `setHeaderRoute` step with `prefix: v1.0`, requests sent through the Traefik gateway:

| `X-Version` | expected backend | plugin from `main` (`v1.0.*`) | this PR (`^v1\.0.*`) |
|---|---|---|---|
| (no header) | blue | blue | blue |
| `v1.0-beta` | green | green | green |
| `v1x0` | blue | **green** | blue |
| `av1.0` | blue | **green** | blue |
| `xv1.0x` | blue | **green** | blue |

The full chainsaw suite (`make run-e2e-tests`, 20 tests) passes on the same cluster with this change.

Tests: `TestPrefixHeaderMatchRegex` checks the generated expression against both interpretations (unanchored search and whole value match) for a plain prefix and for prefixes containing `.` and `+`. `TestHeaderRouteRuleListPrefixIsEscapedAndAnchored` covers the HTTP and GRPC rule builders. The two existing `SetHTTPHeaderRoute` / `SetGRPCHeaderRoute` subtests only change their expected value from `test.*` to `^test.*`.

## Checklist:

* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] My build is green.
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged
* [x] The tests actually define testcases about the feature/fix implemented
* [x] I have run all tests locally and they pass
* [x] I haven't changed the existing tests in a significant way, as this will break functionality for existing users <sup>1</sup>
* [ ] I've updated documentation as required by this PR.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY it works that way according to my use case
* [x] I understand what the code does and HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My new code is using existing utility functions instead of re-implementing everything again
* [ ] Optional. My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md)

Notes

1. Unless a discussion has happened already in an issue and the breaking change is deemed acceptable

