### PR TITLE
ci: protect against future cyclo problems

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,8 @@ linters:
   default: none
   enable:
     - govet
+    - gocognit
+    - gocyclo
     - ineffassign
     - misspell
     - unconvert
@@ -14,6 +16,22 @@ linters:
     - testifylint
     - whitespace
   settings:
+    gocyclo:
+      # Threshold = current worst offender, so existing code passes but future
+      # regressions are caught. Top 3 (gocyclo -top 15 -avg ., 2026-09-07):
+      #   1. 37 HandleExperiment (pkg/plugin/experiment.go:16)
+      #   2. 21 (*RpcPlugin).discoverRoutesBySelector (pkg/plugin/plugin.go:241)
+      #   3. 18 (*RpcPlugin).setHTTPHeaderRoute (pkg/plugin/httproute.go:74),
+      #      (*RpcPlugin).setGRPCHeaderRoute (pkg/plugin/grpcroute.go:69)
+      min-complexity: 37
+    gocognit:
+      # Threshold = current worst offender, so existing code passes but future
+      # regressions are caught. Top 3 (gocognit -top 15 -avg ., 2026-09-07):
+      #   1. 74 HandleExperiment (pkg/plugin/experiment.go:16)
+      #   2. 43 (*RpcPlugin).setGRPCHeaderRoute (pkg/plugin/grpcroute.go:69),
+      #      (*RpcPlugin).setHTTPHeaderRoute (pkg/plugin/httproute.go:74)
+      #   3. 36 (*RpcPlugin).discoverRoutesBySelector (pkg/plugin/plugin.go:241)
+      min-complexity: 74
     staticcheck:
       checks:
         - all


### PR DESCRIPTION


## Description of this PR

Enable cyclomatic complexity in the linter. But don't break the existing build. Use existing thresholds for now
and after https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/issues/206 is implemented we should update

## Checklist:

* [x] I have added a brief description of why this PR is necessary and/or what this PR solves.
* [x] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [x] My build is green.
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged
* [ ] The tests actually define testcases about the feature/fix implemented
* [ ] I have run all tests locally and they pass
* [x] I haven't changed the existing tests in a significant way, as this will break functionality for existing users <sup>1</sup>
* [ ] I've updated documentation as required by this PR.
* [x] I have used LLM/AI/Agent tools for this PR but I am responsible for all code of this PR
* [x] I understand what the code does and WHY it works that way according to my use case
* [x] I understand what the code does and HOW it works in several scenarios
* [x] I know if my code is just adding new functionality or changing old functionality for existing users
* [x] My new code is using existing utility functions instead of re-implementing everything again
* [x] Optional. My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md)

Notes

1. Unless a discussion has happened already in an issue and the breaking change is deemed acceptable
